### PR TITLE
feat(lights): Electron IPC command bus

### DIFF
--- a/packages/ts/lights/electron/main.ts
+++ b/packages/ts/lights/electron/main.ts
@@ -1,6 +1,7 @@
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, ipcMain } from 'electron'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
+import type { GraphCommand, GraphEvent } from '../src/ipc/types'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -8,8 +9,45 @@ process.env.APP_ROOT = path.join(__dirname, '..')
 
 const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL
 
+let win: BrowserWindow | null = null
+let stubInterval: ReturnType<typeof setInterval> | null = null
+
+function emit(event: GraphEvent) {
+  win?.webContents.send('graph:event', event)
+}
+
+function startStubGraph() {
+  if (stubInterval !== null) {
+    clearInterval(stubInterval)
+    stubInterval = null
+  }
+  emit({ type: 'graph:status', status: 'running' })
+  stubInterval = setInterval(() => {
+    emit({ type: 'frame', data: new ArrayBuffer(0) })
+  }, 33)
+}
+
+function stopStubGraph() {
+  if (stubInterval !== null) {
+    clearInterval(stubInterval)
+    stubInterval = null
+  }
+  emit({ type: 'graph:status', status: 'stopped' })
+}
+
+ipcMain.on('graph:command', (_event, cmd: GraphCommand) => {
+  switch (cmd.type) {
+    case 'slide:activate':
+      startStubGraph()
+      break
+    case 'graph:stop':
+      stopStubGraph()
+      break
+  }
+})
+
 function createWindow() {
-  const win = new BrowserWindow({
+  win = new BrowserWindow({
     width: 1280,
     height: 720,
     backgroundColor: '#0a0a0a',
@@ -18,6 +56,11 @@ function createWindow() {
       preload: path.join(__dirname, 'preload.mjs'),
       contextIsolation: true,
     },
+  })
+
+  win.on('closed', () => {
+    stopStubGraph()
+    win = null
   })
 
   if (DEV_SERVER_URL) {

--- a/packages/ts/lights/electron/preload.ts
+++ b/packages/ts/lights/electron/preload.ts
@@ -1,4 +1,13 @@
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
+import type { GraphCommand, GraphEvent, LightsBridge } from '../src/ipc/types'
 
-// IPC bridge will be wired in issue #7
-contextBridge.exposeInMainWorld('lights', {})
+const bridge: LightsBridge = {
+  sendCommand: (cmd: GraphCommand) => ipcRenderer.send('graph:command', cmd),
+  onEvent: (handler: (event: GraphEvent) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, event: GraphEvent) => handler(event)
+    ipcRenderer.on('graph:event', listener)
+    return () => ipcRenderer.off('graph:event', listener)
+  },
+}
+
+contextBridge.exposeInMainWorld('lights', bridge)

--- a/packages/ts/lights/src/App.tsx
+++ b/packages/ts/lights/src/App.tsx
@@ -1,7 +1,17 @@
+import { useEffect, useState } from 'react'
+
 export default function App() {
+  const [status, setStatus] = useState<'connected' | 'running' | 'stopped' | 'error'>('connected')
+
+  useEffect(() => {
+    return window.lights.onEvent((event) => {
+      if (event.type === 'graph:status') setStatus(event.status)
+    })
+  }, [])
+
   return (
     <div className="app">
-      <span className="status">connecting...</span>
+      <span className="status">{status}</span>
     </div>
   )
 }

--- a/packages/ts/lights/src/ipc/types.ts
+++ b/packages/ts/lights/src/ipc/types.ts
@@ -1,0 +1,47 @@
+export interface Point {
+  x: number
+  y: number
+}
+
+export interface Pattern {
+  width: number
+  height: number
+  data: ArrayBuffer
+}
+
+export interface GraphConfig {
+  modules: Record<string, { enabled: boolean; params?: Record<string, unknown> }>
+}
+
+export type AOIMap = Record<string, Point[]>
+
+export interface Surface {
+  id: string
+  name: string
+  outputPolygon: Point[]
+}
+
+export type GraphCommand =
+  | { type: 'calibration:start' }
+  | { type: 'calibration:stop' }
+  | { type: 'slide:activate'; config: GraphConfig; aois: AOIMap }
+  | { type: 'module:setParams'; moduleId: string; params: Record<string, unknown> }
+  | { type: 'graph:stop' }
+
+export type GraphEvent =
+  | { type: 'calibration:project'; pattern: Pattern }
+  | { type: 'calibration:result'; surfaces: Surface[] }
+  | { type: 'frame'; data: ArrayBuffer }
+  | { type: 'detection'; moduleId: string; position: Point; data: unknown }
+  | { type: 'graph:status'; status: 'running' | 'stopped' | 'error' }
+
+export interface LightsBridge {
+  sendCommand: (cmd: GraphCommand) => void
+  onEvent: (handler: (event: GraphEvent) => void) => () => void
+}
+
+declare global {
+  interface Window {
+    lights: LightsBridge
+  }
+}


### PR DESCRIPTION
## Summary

- Defines shared `GraphCommand` / `GraphEvent` types in `src/ipc/types.ts`, including a `LightsBridge` interface that augments `Window` for full renderer type safety
- Wires the preload bridge: `sendCommand` sends to main via `ipcRenderer.send`, `onEvent` subscribes via `ipcRenderer.on` and returns an unsubscribe function
- Adds `ipcMain` handler in main: `slide:activate` starts a 30fps stub frame emitter, `graph:stop` stops it; window close cleans up the interval
- Updates `App.tsx` to subscribe to `graph:status` events and reflect them in the UI

The stub graph emits empty `ArrayBuffer` frames at 30fps — enough to prove the channel end-to-end. Issue #8 will replace them with real Three.js rendering.

Closes #7

## Test plan

- [ ] `yarn nx typecheck lights` passes
- [ ] `yarn nx serve lights` launches the app; status shows `connected`
- [ ] Calling `window.lights.sendCommand({ type: 'slide:activate', config: { modules: {} }, aois: {} })` in DevTools changes status to `running`
- [ ] Calling `window.lights.sendCommand({ type: 'graph:stop' })` changes status back to `stopped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)