### PR TITLE
feat(lights): Three.js canvas with live frame rendering

### DIFF
--- a/packages/ts/lights/electron/main.ts
+++ b/packages/ts/lights/electron/main.ts
@@ -23,7 +23,7 @@ function startStubGraph() {
   }
   emit({ type: 'graph:status', status: 'running' })
   stubInterval = setInterval(() => {
-    emit({ type: 'frame', data: new ArrayBuffer(0) })
+    emit({ type: 'frame', width: 320, height: 240, data: new ArrayBuffer(0) })
   }, 33)
 }
 

--- a/packages/ts/lights/package.json
+++ b/packages/ts/lights/package.json
@@ -9,12 +9,15 @@
     "targets": {
       "typecheck": {
         "command": "tsc --noEmit",
-        "options": { "cwd": "{projectRoot}" }
+        "options": {
+          "cwd": "{projectRoot}"
+        }
       }
     }
   },
   "dependencies": {
     "react": "*",
-    "react-dom": "*"
+    "react-dom": "*",
+    "three": "^0.184.0"
   }
 }

--- a/packages/ts/lights/src/App.tsx
+++ b/packages/ts/lights/src/App.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
+import Canvas from './Canvas'
 
 export default function App() {
-  const [status, setStatus] = useState<'connected' | 'running' | 'stopped' | 'error'>('connected')
+  const [status, setStatus] = useState<'running' | 'stopped' | 'error'>('stopped')
 
   useEffect(() => {
     return window.lights.onEvent((event) => {
@@ -11,6 +12,7 @@ export default function App() {
 
   return (
     <div className="app">
+      <Canvas />
       <span className="status">{status}</span>
     </div>
   )

--- a/packages/ts/lights/src/Canvas.tsx
+++ b/packages/ts/lights/src/Canvas.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react'
+import * as THREE from 'three'
+
+export default function Canvas() {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = containerRef.current!
+
+    const renderer = new THREE.WebGLRenderer({ antialias: false })
+    renderer.setPixelRatio(window.devicePixelRatio)
+    renderer.setSize(container.clientWidth, container.clientHeight)
+    container.appendChild(renderer.domElement)
+
+    const scene = new THREE.Scene()
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+
+    let frameW = 1
+    let frameH = 1
+    let frameBuffer = new Uint8Array(4)
+    let texture = new THREE.DataTexture(frameBuffer, 1, 1)
+
+    const geometry = new THREE.PlaneGeometry(2, 2)
+    const material = new THREE.MeshBasicMaterial({ map: texture })
+    const mesh = new THREE.Mesh(geometry, material)
+    scene.add(mesh)
+
+    function updateAspect() {
+      const winAspect = container.clientWidth / container.clientHeight
+      const frameAspect = frameW / frameH
+      if (winAspect > frameAspect) {
+        mesh.scale.set(frameAspect / winAspect, 1, 1)
+      } else {
+        mesh.scale.set(1, winAspect / frameAspect, 1)
+      }
+      renderer.setSize(container.clientWidth, container.clientHeight)
+      renderer.render(scene, camera)
+    }
+
+    function ensureTexture(w: number, h: number) {
+      if (w === frameW && h === frameH) return
+      texture.dispose()
+      frameW = w
+      frameH = h
+      frameBuffer = new Uint8Array(w * h * 4)
+      texture = new THREE.DataTexture(frameBuffer, w, h)
+      material.map = texture
+      material.needsUpdate = true
+      updateAspect()
+    }
+
+    updateAspect()
+
+    const off = window.lights.onEvent((event) => {
+      if (event.type !== 'frame') return
+      ensureTexture(event.width, event.height)
+      // Copy RGB24 → RGBA32 into the reused buffer (no allocation)
+      if (event.data.byteLength === frameW * frameH * 3) {
+        const src = new Uint8Array(event.data)
+        for (let i = 0; i < frameW * frameH; i++) {
+          frameBuffer[i * 4] = src[i * 3]
+          frameBuffer[i * 4 + 1] = src[i * 3 + 1]
+          frameBuffer[i * 4 + 2] = src[i * 3 + 2]
+          frameBuffer[i * 4 + 3] = 255
+        }
+        texture.needsUpdate = true
+      }
+      renderer.render(scene, camera)
+    })
+
+    const observer = new ResizeObserver(updateAspect)
+    observer.observe(container)
+
+    return () => {
+      off()
+      observer.disconnect()
+      geometry.dispose()
+      material.dispose()
+      texture.dispose()
+      renderer.dispose()
+      container.removeChild(renderer.domElement)
+    }
+  }, [])
+
+  return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+}

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -14,17 +14,16 @@ html, body, #root {
   width: 100%;
   height: 100%;
   background: #0a0a0a;
-  color: #fff;
-  font-family: system-ui, sans-serif;
-  display: flex;
-  align-items: flex-start;
-  justify-content: flex-end;
-  padding: 12px;
+  position: relative;
 }
 
 .status {
+  position: absolute;
+  top: 12px;
+  right: 12px;
   font-size: 11px;
   color: #555;
+  font-family: system-ui, sans-serif;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }

--- a/packages/ts/lights/src/ipc/types.ts
+++ b/packages/ts/lights/src/ipc/types.ts
@@ -31,7 +31,7 @@ export type GraphCommand =
 export type GraphEvent =
   | { type: 'calibration:project'; pattern: Pattern }
   | { type: 'calibration:result'; surfaces: Surface[] }
-  | { type: 'frame'; data: ArrayBuffer }
+  | { type: 'frame'; width: number; height: number; data: ArrayBuffer }
   | { type: 'detection'; moduleId: string; position: Point; data: unknown }
   | { type: 'graph:status'; status: 'running' | 'stopped' | 'error' }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,6 +858,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
   integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
 
+"@dimforge/rapier3d-compat@~0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz#7b3365e1dfdc5cd957b45afe920b4ac06c7cd389"
+  integrity sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==
+
 "@electron/get@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.3.tgz#fba552683d387aebd9f3fcadbcafc8e12ee4f960"
@@ -1539,6 +1544,11 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tweenjs/tween.js@~23.1.3":
+  version "23.1.3"
+  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-23.1.3.tgz#eff0245735c04a928bb19c026b58c2a56460539d"
+  integrity sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==
+
 "@tybys/wasm-util@0.9.0", "@tybys/wasm-util@^0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.9.0.tgz#3e75eb00604c8d6db470bf18c37b7d984a0e3355"
@@ -1654,6 +1664,28 @@
   integrity sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==
   dependencies:
     "@types/node" "*"
+
+"@types/stats.js@*":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.4.tgz#1933e5ff153a23c7664487833198d685c22e791e"
+  integrity sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==
+
+"@types/three@^0.184.0":
+  version "0.184.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.184.0.tgz#f6a3ea283bebb65e5de6ff4dbf18ef57bdcf5bcc"
+  integrity sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==
+  dependencies:
+    "@dimforge/rapier3d-compat" "~0.12.0"
+    "@tweenjs/tween.js" "~23.1.3"
+    "@types/stats.js" "*"
+    "@types/webxr" ">=0.5.17"
+    fflate "~0.8.2"
+    meshoptimizer "~1.1.1"
+
+"@types/webxr@>=0.5.17":
+  version "0.5.24"
+  resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.5.24.tgz#734d5d90dadc5809a53e422726c60337fa2f4a44"
+  integrity sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==
 
 "@types/ws@^8.18.1":
   version "8.18.1"
@@ -2584,6 +2616,11 @@ fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+fflate@~0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 figures@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -3159,6 +3196,11 @@ math-intrinsics@1.1.0, math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+meshoptimizer@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/meshoptimizer/-/meshoptimizer-1.1.1.tgz#20c7d050d59bdc573154814f6a37d47d89908cca"
+  integrity sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -3577,14 +3619,14 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-react-dom@^19.2.5:
+react-dom@*, react-dom@^19.2.5:
   version "19.2.5"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
   integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
   dependencies:
     scheduler "^0.27.0"
 
-react@^19.2.5:
+react@*, react@^19.2.5:
   version "19.2.5"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
   integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
@@ -3884,6 +3926,11 @@ tar-stream@2.2.0:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
+
+three@^0.184.0:
+  version "0.184.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.184.0.tgz#5bca0a3851eea5345e4c205567b40dfa49b791b5"
+  integrity sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==
 
 tinybench@^2.9.0:
   version "2.9.0"


### PR DESCRIPTION
## Summary

- Adds `width` + `height` to the `frame` event type so the renderer is resolution-agnostic from day one; updates the stub to emit `320×240`
- New `Canvas.tsx`: `WebGLRenderer` fills the container, `DataTexture` (RGBA) updated in-place each frame — no per-frame allocation. RGB24 → RGBA32 conversion writes into the reused buffer
- Texture is recreated only when frame dimensions change (resolution switch); no GC pressure on normal playback
- `ResizeObserver` keeps the feed letterboxed/pillarboxed at the correct aspect ratio on every window resize
- `App.tsx` now renders `Canvas` with the status pill overlaid absolutely at top-right
- `app.css` updated: `.app` uses `position: relative` to anchor the overlay

Closes #8

## Test plan

- [ ] `yarn nx typecheck lights` passes
- [ ] `yarn nx serve lights` launches; black canvas visible, status shows `stopped`
- [ ] `window.lights.sendCommand({ type: 'slide:activate', config: { modules: {} }, aois: {} })` → status flips to `running` (stub graph starts emitting frames)
- [ ] Resizing the window keeps the black quad letterboxed (no stretching)
- [ ] DevTools shows no repeated allocations during frame events

🤖 Generated with [Claude Code](https://claude.com/claude-code)