### PR TITLE
feat(lights): project data model & state management

### DIFF
--- a/packages/ts/lights/src/ipc/types.ts
+++ b/packages/ts/lights/src/ipc/types.ts
@@ -15,7 +15,7 @@ export interface GraphConfig {
 
 export type AOIMap = Record<string, Point[]>
 
-export interface Surface {
+export interface SurfaceGeometry {
   id: string
   name: string
   outputPolygon: Point[]
@@ -30,7 +30,7 @@ export type GraphCommand =
 
 export type GraphEvent =
   | { type: 'calibration:project'; pattern: Pattern }
-  | { type: 'calibration:result'; surfaces: Surface[] }
+  | { type: 'calibration:result'; surfaces: SurfaceGeometry[] }
   | { type: 'frame'; width: number; height: number; data: ArrayBuffer }
   | { type: 'detection'; moduleId: string; position: Point; data: ArrayBuffer }
   | { type: 'graph:status'; status: 'running' | 'stopped' | 'error' }

--- a/packages/ts/lights/src/main.tsx
+++ b/packages/ts/lights/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './app.css'
 import App from './App'
+import { ProjectProvider } from './model/ProjectContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ProjectProvider>
+      <App />
+    </ProjectProvider>
   </StrictMode>
 )

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -1,0 +1,158 @@
+import { createContext, useContext, useEffect, useReducer } from 'react'
+import type { Dispatch, ReactNode } from 'react'
+import type { Project, Slide, Surface } from './types'
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+export interface ProjectState {
+  project: Project
+  selectedSlideId: string | null
+  selectedSurfaceId: string | null
+}
+
+const initial: ProjectState = {
+  project: { slides: [], calibration: {} },
+  selectedSlideId: null,
+  selectedSurfaceId: null,
+}
+
+// ── Actions ──────────────────────────────────────────────────────────────────
+
+export type ProjectAction =
+  | { type: 'slide:add' }
+  | { type: 'slide:remove'; slideId: string }
+  | { type: 'slide:select'; slideId: string | null }
+  | { type: 'surface:add'; slideId: string }
+  | { type: 'surface:update'; slideId: string; surface: Surface }
+  | { type: 'surface:remove'; slideId: string; surfaceId: string }
+  | { type: 'surface:select'; surfaceId: string | null }
+
+// ── Reducer ──────────────────────────────────────────────────────────────────
+
+function reducer(state: ProjectState, action: ProjectAction): ProjectState {
+  const { project } = state
+
+  switch (action.type) {
+    case 'slide:add': {
+      const slide: Slide = {
+        id: crypto.randomUUID(),
+        name: `Slide ${project.slides.length + 1}`,
+        surfaces: [],
+        graphConfig: { modules: {} },
+      }
+      return {
+        ...state,
+        project: { ...project, slides: [...project.slides, slide] },
+        selectedSlideId: slide.id,
+        selectedSurfaceId: null,
+      }
+    }
+
+    case 'slide:remove': {
+      const slides = project.slides.filter(s => s.id !== action.slideId)
+      const selectedSlideId =
+        state.selectedSlideId === action.slideId
+          ? (slides[0]?.id ?? null)
+          : state.selectedSlideId
+      return {
+        ...state,
+        project: { ...project, slides },
+        selectedSlideId,
+        selectedSurfaceId: null,
+      }
+    }
+
+    case 'slide:select':
+      return { ...state, selectedSlideId: action.slideId, selectedSurfaceId: null }
+
+    case 'surface:add': {
+      const surface: Surface = {
+        id: crypto.randomUUID(),
+        name: `Surface ${(project.slides.find(s => s.id === action.slideId)?.surfaces.length ?? 0) + 1}`,
+        outputPolygon: [
+          { x: 0.25, y: 0.25 },
+          { x: 0.75, y: 0.25 },
+          { x: 0.75, y: 0.75 },
+          { x: 0.25, y: 0.75 },
+        ],
+        layers: [],
+        reactions: [],
+      }
+      return {
+        ...state,
+        project: {
+          ...project,
+          slides: project.slides.map(s =>
+            s.id === action.slideId ? { ...s, surfaces: [...s.surfaces, surface] } : s
+          ),
+        },
+      }
+    }
+
+    case 'surface:update':
+      return {
+        ...state,
+        project: {
+          ...project,
+          slides: project.slides.map(s =>
+            s.id === action.slideId
+              ? { ...s, surfaces: s.surfaces.map(sf => sf.id === action.surface.id ? action.surface : sf) }
+              : s
+          ),
+        },
+      }
+
+    case 'surface:remove': {
+      const selectedSurfaceId =
+        state.selectedSurfaceId === action.surfaceId ? null : state.selectedSurfaceId
+      return {
+        ...state,
+        project: {
+          ...project,
+          slides: project.slides.map(s =>
+            s.id === action.slideId
+              ? { ...s, surfaces: s.surfaces.filter(sf => sf.id !== action.surfaceId) }
+              : s
+          ),
+        },
+        selectedSurfaceId,
+      }
+    }
+
+    case 'surface:select':
+      return { ...state, selectedSurfaceId: action.surfaceId }
+  }
+}
+
+// ── Context ──────────────────────────────────────────────────────────────────
+
+interface ContextValue {
+  state: ProjectState
+  dispatch: Dispatch<ProjectAction>
+}
+
+const ProjectContext = createContext<ContextValue | null>(null)
+
+export function ProjectProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initial)
+
+  // Activate the selected slide on the backend whenever it changes
+  useEffect(() => {
+    if (state.selectedSlideId === null) return
+    const slide = state.project.slides.find(s => s.id === state.selectedSlideId)
+    if (!slide) return
+    const aois: Record<string, { x: number; y: number }[]> = {}
+    for (const surface of slide.surfaces) {
+      if (surface.areaOfInterest) aois[surface.id] = surface.areaOfInterest
+    }
+    window.lights.sendCommand({ type: 'slide:activate', config: slide.graphConfig, aois })
+  }, [state.selectedSlideId, state.project.slides])
+
+  return <ProjectContext.Provider value={{ state, dispatch }}>{children}</ProjectContext.Provider>
+}
+
+export function useProject(): ContextValue {
+  const ctx = useContext(ProjectContext)
+  if (!ctx) throw new Error('useProject must be used within ProjectProvider')
+  return ctx
+}

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -1,0 +1,39 @@
+import type { Point, GraphConfig } from '../ipc/types'
+
+export type { Point, GraphConfig }
+
+export type Polygon = Point[]
+
+// Stubs — filled out in M3 (layers) and M4 (reactions)
+export interface Layer { id: string; type: string }
+export interface Reaction { id: string }
+export interface Calibration {}
+
+export interface Surface {
+  id: string
+  name: string
+  outputPolygon: [Point, Point, Point, Point]
+  areaOfInterest?: Polygon
+  layers: Layer[]
+  reactions: Reaction[]
+}
+
+export interface Slide {
+  id: string
+  name: string
+  surfaces: Surface[]
+  graphConfig: GraphConfig
+}
+
+export interface Project {
+  slides: Slide[]
+  calibration: Calibration
+}
+
+export function deriveAOIs(surfaces: Surface[]): Record<string, Polygon> {
+  const map: Record<string, Polygon> = {}
+  for (const s of surfaces) {
+    if (s.areaOfInterest) map[s.id] = s.areaOfInterest
+  }
+  return map
+}

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -7,7 +7,8 @@ export type Polygon = Point[]
 // Stubs — filled out in M3 (layers) and M4 (reactions)
 export interface Layer { id: string; type: string }
 export interface Reaction { id: string }
-export interface Calibration {}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface Calibration {} // populated by M5 (camera-to-projector mapping)
 
 export interface Surface {
   id: string


### PR DESCRIPTION
## Summary

- Renames `Surface` → `SurfaceGeometry` in `ipc/types.ts` (used only in `calibration:result`) to free the name for the full model type
- `src/model/types.ts` — `Project`, `Slide`, `Surface`, `Layer`, `Reaction`, `Calibration` types; `Surface.outputPolygon` typed as a 4-tuple; `deriveAOIs()` helper
- `src/model/ProjectContext.tsx` — `useReducer`-based context with typed actions for slides (`add`/`remove`/`select`) and surfaces (`add`/`update`/`remove`/`select`); provider side-effect activates the selected slide on the backend via `sendCommand` when `selectedSlideId` changes
- `src/main.tsx` — wraps `<App>` with `<ProjectProvider>`

Closes #14

## Test plan

- [ ] `yarn nx typecheck lights` passes
- [ ] App still launches and canvas renders as before (no regression)
- [ ] `useProject()` accessible from any component inside the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)