### PR TITLE
feat(lights): stage layout & slide panel

### DIFF
--- a/packages/ts/lights/electron/main.ts
+++ b/packages/ts/lights/electron/main.ts
@@ -77,6 +77,7 @@ function createWindow() {
   win = new BrowserWindow({
     width: 1280,
     height: 720,
+    fullscreen: true,
     backgroundColor: '#0a0a0a',
     titleBarStyle: 'hiddenInset',
     webPreferences: {

--- a/packages/ts/lights/src/App.tsx
+++ b/packages/ts/lights/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Canvas from './Canvas'
+import SlidePanel from './SlidePanel'
 
 export default function App() {
   const [status, setStatus] = useState<'running' | 'stopped' | 'error'>('stopped')
@@ -12,8 +13,13 @@ export default function App() {
 
   return (
     <div className="app">
-      <Canvas />
-      <span className="status">{status}</span>
+      <SlidePanel />
+      <div className="stage-area">
+        <div className="stage-canvas">
+          <Canvas />
+        </div>
+        <span className="status">{status}</span>
+      </div>
     </div>
   )
 }

--- a/packages/ts/lights/src/SlidePanel.tsx
+++ b/packages/ts/lights/src/SlidePanel.tsx
@@ -1,0 +1,43 @@
+import { useProject } from './model/ProjectContext'
+
+export default function SlidePanel() {
+  const { state, dispatch } = useProject()
+  const { project, selectedSlideId } = state
+
+  return (
+    <aside className="slide-panel">
+      <div className="slide-panel-header">
+        <span>Slides</span>
+        <button
+          className="icon-btn"
+          title="Add slide"
+          onClick={() => dispatch({ type: 'slide:add' })}
+        >
+          +
+        </button>
+      </div>
+
+      <div className="slide-list">
+        {project.slides.map((slide) => (
+          <div
+            key={slide.id}
+            className={`slide-item${slide.id === selectedSlideId ? ' selected' : ''}`}
+            onClick={() => dispatch({ type: 'slide:select', slideId: slide.id })}
+          >
+            <span className="slide-name">{slide.name}</span>
+            <button
+              className="icon-btn slide-remove"
+              title="Remove slide"
+              onClick={(e) => {
+                e.stopPropagation()
+                dispatch({ type: 'slide:remove', slideId: slide.id })
+              }}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -10,20 +10,140 @@ html, body, #root {
   overflow: hidden;
 }
 
+/* ── Root layout ─────────────────────────────────────────────────────────── */
+
 .app {
   width: 100%;
   height: 100%;
+  display: flex;
   background: #0a0a0a;
-  position: relative;
+  color: #fff;
+  font-family: system-ui, sans-serif;
 }
+
+/* ── Slide panel ─────────────────────────────────────────────────────────── */
+
+.slide-panel {
+  width: 200px;
+  min-width: 200px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #111;
+  border-right: 1px solid #222;
+}
+
+.slide-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 12px 10px;
+  font-size: 10px;
+  color: #555;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.slide-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 8px;
+}
+
+.slide-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #777;
+}
+
+.slide-item:hover {
+  background: #1a1a1a;
+  color: #ccc;
+}
+
+.slide-item.selected {
+  background: #1a2744;
+  color: #60a5fa;
+}
+
+.slide-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.slide-remove {
+  opacity: 0;
+  margin-left: 6px;
+  color: #555;
+}
+
+.slide-item:hover .slide-remove,
+.slide-item.selected .slide-remove {
+  opacity: 1;
+}
+
+.slide-remove:hover {
+  color: #ef4444 !important;
+}
+
+/* ── Shared icon button ──────────────────────────────────────────────────── */
+
+.icon-btn {
+  background: none;
+  border: 1px solid #2a2a2a;
+  color: #666;
+  cursor: pointer;
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.icon-btn:hover {
+  border-color: #444;
+  color: #ccc;
+}
+
+/* ── Stage area ──────────────────────────────────────────────────────────── */
+
+.stage-area {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #161616;
+  position: relative;
+  overflow: hidden;
+}
+
+.stage-canvas {
+  aspect-ratio: 16 / 9;
+  max-width: 100%;
+  max-height: 100%;
+  position: relative;
+  background: #0a0a0a;
+}
+
+/* ── Status pill ─────────────────────────────────────────────────────────── */
 
 .status {
   position: absolute;
-  top: 12px;
+  bottom: 10px;
   right: 12px;
-  font-size: 11px;
-  color: #555;
-  font-family: system-ui, sans-serif;
-  letter-spacing: 0.05em;
+  font-size: 10px;
+  color: #3a3a3a;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }


### PR DESCRIPTION
## Summary

- New two-column layout: 200px slide panel on the left, stage area fills the rest
- Stage canvas is letterboxed at **16:9** via CSS `aspect-ratio` — no JS needed, ResizeObserver in Canvas.tsx handles the rest automatically
- `SlidePanel.tsx` — add/remove/select slides via `ProjectContext` dispatch
- Status pill moved to bottom-right of the stage area
- `app.css` rewritten with the new layout and component styles

Closes #15

## Test plan

- [ ] `yarn nx typecheck lights` + `yarn nx lint lights` pass
- [ ] App launches showing the slide panel on the left and black stage canvas on the right
- [ ] "+" adds a slide to the panel; clicking it selects it (highlighted blue)
- [ ] "×" removes a slide
- [ ] Stage canvas maintains 16:9 ratio when resizing the window
- [ ] Frame feed (after `slide:activate` in console) renders correctly inside the 16:9 stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)