### PR TITLE
feat(lights): surface quad placement on stage

### DIFF
--- a/packages/ts/lights/src/App.tsx
+++ b/packages/ts/lights/src/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import Canvas from './Canvas'
 import SlidePanel from './SlidePanel'
+import StageOverlay from './StageOverlay'
+import SurfacePanel from './SurfacePanel'
 
 export default function App() {
   const [status, setStatus] = useState<'running' | 'stopped' | 'error'>('stopped')
@@ -17,9 +19,11 @@ export default function App() {
       <div className="stage-area">
         <div className="stage-canvas">
           <Canvas />
+          <StageOverlay />
         </div>
         <span className="status">{status}</span>
       </div>
+      <SurfacePanel />
     </div>
   )
 }

--- a/packages/ts/lights/src/StageOverlay.tsx
+++ b/packages/ts/lights/src/StageOverlay.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+import { useProject } from './model/ProjectContext'
+import type { Surface } from './model/types'
+import type { Point } from './model/types'
+
+type DragState = {
+  surfaceId: string
+  slideId: string
+  cornerIdx: number
+  polygon: [Point, Point, Point, Point]
+} | null
+
+export default function StageOverlay() {
+  const { state, dispatch } = useProject()
+  const svgRef = useRef<SVGSVGElement>(null)
+  const [size, setSize] = useState({ w: 0, h: 0 })
+  const [drag, setDrag] = useState<DragState>(null)
+
+  useEffect(() => {
+    const el = svgRef.current!
+    const obs = new ResizeObserver(([e]) => {
+      setSize({ w: e.contentRect.width, h: e.contentRect.height })
+    })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [])
+
+  const { project, selectedSlideId, selectedSurfaceId } = state
+  const slide = project.slides.find(s => s.id === selectedSlideId)
+  const surfaces = slide?.surfaces ?? []
+
+  function toNorm(clientX: number, clientY: number): Point {
+    const rect = svgRef.current!.getBoundingClientRect()
+    return {
+      x: Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)),
+      y: Math.max(0, Math.min(1, (clientY - rect.top) / rect.height)),
+    }
+  }
+
+  function px(p: Point) {
+    return { x: p.x * size.w, y: p.y * size.h }
+  }
+
+  function centroid(polygon: [Point, Point, Point, Point]): Point {
+    return {
+      x: polygon.reduce((s, p) => s + p.x, 0) / 4,
+      y: polygon.reduce((s, p) => s + p.y, 0) / 4,
+    }
+  }
+
+  function onCornerDown(
+    e: ReactPointerEvent<SVGCircleElement>,
+    surface: Surface,
+    slideId: string,
+    idx: number
+  ) {
+    e.stopPropagation()
+    svgRef.current!.setPointerCapture(e.pointerId)
+    setDrag({
+      surfaceId: surface.id,
+      slideId,
+      cornerIdx: idx,
+      polygon: [...surface.outputPolygon] as [Point, Point, Point, Point],
+    })
+  }
+
+  function onPointerMove(e: ReactPointerEvent<SVGSVGElement>) {
+    if (!drag) return
+    const pt = toNorm(e.clientX, e.clientY)
+    const polygon = drag.polygon.map((p, i) => (i === drag.cornerIdx ? pt : p)) as [Point, Point, Point, Point]
+    setDrag({ ...drag, polygon })
+  }
+
+  function onPointerUp() {
+    if (!drag) return
+    const surface = surfaces.find(s => s.id === drag.surfaceId)
+    if (surface) {
+      dispatch({
+        type: 'surface:update',
+        slideId: drag.slideId,
+        surface: { ...surface, outputPolygon: drag.polygon },
+      })
+    }
+    setDrag(null)
+  }
+
+  if (size.w === 0) return <svg ref={svgRef} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} />
+
+  return (
+    <svg
+      ref={svgRef}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        cursor: drag ? 'grabbing' : 'default',
+        overflow: 'visible',
+      }}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    >
+      {surfaces.map(surface => {
+        const polygon = drag?.surfaceId === surface.id ? drag.polygon : surface.outputPolygon
+        const selected = surface.id === selectedSurfaceId
+        const c = px(centroid(polygon))
+        const pointsStr = polygon.map(p => { const q = px(p); return `${q.x},${q.y}` }).join(' ')
+
+        return (
+          <g key={surface.id}>
+            <polygon
+              points={pointsStr}
+              fill={selected ? 'rgba(96,165,250,0.1)' : 'rgba(255,255,255,0.04)'}
+              stroke={selected ? '#60a5fa' : '#555'}
+              strokeWidth={selected ? 1.5 : 1}
+              style={{ cursor: 'pointer' }}
+              onClick={() => dispatch({ type: 'surface:select', surfaceId: surface.id })}
+            />
+            <text
+              x={c.x}
+              y={c.y}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={11}
+              fill={selected ? '#60a5fa' : '#555'}
+              style={{ pointerEvents: 'none', userSelect: 'none' }}
+            >
+              {surface.name}
+            </text>
+            {polygon.map((p, idx) => {
+              const { x, y } = px(p)
+              return (
+                <circle
+                  key={idx}
+                  cx={x}
+                  cy={y}
+                  r={6}
+                  fill={selected ? '#1e40af' : '#2a2a2a'}
+                  stroke={selected ? '#60a5fa' : '#555'}
+                  strokeWidth={1.5}
+                  style={{ cursor: drag ? 'grabbing' : 'grab' }}
+                  onPointerDown={e => onCornerDown(e, surface, selectedSlideId!, idx)}
+                />
+              )
+            })}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}

--- a/packages/ts/lights/src/SurfacePanel.tsx
+++ b/packages/ts/lights/src/SurfacePanel.tsx
@@ -1,0 +1,54 @@
+import { useProject } from './model/ProjectContext'
+
+export default function SurfacePanel() {
+  const { state, dispatch } = useProject()
+  const { project, selectedSlideId, selectedSurfaceId } = state
+
+  const slide = project.slides.find(s => s.id === selectedSlideId)
+  const surfaces = slide?.surfaces ?? []
+
+  return (
+    <aside className="surface-panel">
+      <div className="surface-panel-header">
+        <span>Surfaces</span>
+        {selectedSlideId && (
+          <button
+            className="icon-btn"
+            title="Add surface"
+            onClick={() => dispatch({ type: 'surface:add', slideId: selectedSlideId })}
+          >
+            +
+          </button>
+        )}
+      </div>
+
+      {!selectedSlideId ? (
+        <p className="panel-empty">No slide selected</p>
+      ) : surfaces.length === 0 ? (
+        <p className="panel-empty">No surfaces</p>
+      ) : (
+        <div className="surface-list">
+          {surfaces.map(surface => (
+            <div
+              key={surface.id}
+              className={`surface-item${surface.id === selectedSurfaceId ? ' selected' : ''}`}
+              onClick={() => dispatch({ type: 'surface:select', surfaceId: surface.id })}
+            >
+              <span className="surface-name">{surface.name}</span>
+              <button
+                className="icon-btn surface-remove"
+                title="Remove surface"
+                onClick={e => {
+                  e.stopPropagation()
+                  dispatch({ type: 'surface:remove', slideId: selectedSlideId, surfaceId: surface.id })
+                }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -136,6 +136,85 @@ html, body, #root {
   background: #0a0a0a;
 }
 
+/* ── Surface panel (right sidebar) ──────────────────────────────────────── */
+
+.surface-panel {
+  width: 200px;
+  min-width: 200px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #111;
+  border-left: 1px solid #222;
+}
+
+.surface-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 12px 10px;
+  font-size: 10px;
+  color: #555;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.panel-empty {
+  padding: 16px 12px;
+  font-size: 11px;
+  color: #333;
+  text-align: center;
+}
+
+.surface-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 8px;
+}
+
+.surface-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #777;
+}
+
+.surface-item:hover {
+  background: #1a1a1a;
+  color: #ccc;
+}
+
+.surface-item.selected {
+  background: #1a2744;
+  color: #60a5fa;
+}
+
+.surface-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.surface-remove {
+  opacity: 0;
+  margin-left: 6px;
+  color: #555;
+}
+
+.surface-item:hover .surface-remove,
+.surface-item.selected .surface-remove {
+  opacity: 1;
+}
+
+.surface-remove:hover {
+  color: #ef4444 !important;
+}
+
 /* ── Status pill ─────────────────────────────────────────────────────────── */
 
 .status {


### PR DESCRIPTION
Closes #16

## Summary
- **StageOverlay**: SVG overlay absolutely positioned over the stage canvas. Each surface renders as a polygon outline with 4 draggable corner handles. Pointer capture on the SVG root ensures drag continues when the cursor moves fast.
- **SurfacePanel**: right sidebar (mirrors SlidePanel style) with surface list, add (+) and remove (×) controls, and selection highlight.
- Coordinates stay normalized [0,1] in the model; the overlay maps to pixel space via a ResizeObserver on the SVG element.

## Test plan
- [ ] Add a slide → Add surface → quad appears centered on stage
- [ ] Drag each of the 4 corners — quad updates in real time, persists on release
- [ ] Corner stays within stage bounds when dragged to edge
- [ ] Clicking a surface in the stage or the surface panel selects it (blue highlight)
- [ ] Remove surface via × in panel — quad disappears
- [ ] Switch slides — surfaces per slide are independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)