### PR TITLE
feat(lights): homography GLSL shader for surface meshes (#17)

### DIFF
--- a/packages/ts/lights/src/Canvas.tsx
+++ b/packages/ts/lights/src/Canvas.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import * as THREE from 'three'
+import { useProject } from './model/ProjectContext'
+import { buildSurfaceMesh, disposeSurfaceMesh } from './homography'
 
 // ── MediaPipe topology ───────────────────────────────────────────────────────
 
@@ -170,11 +172,21 @@ function drawFaces(ctx: CanvasRenderingContext2D, faces: Landmark[][], r: Rect) 
 
 export default function Canvas() {
   const containerRef = useRef<HTMLDivElement>(null)
+  const renderRef = useRef<() => void>(() => {})
+  const surfaceGroupRef = useRef<THREE.Group | null>(null)
 
+  const { state } = useProject()
+  const { project, selectedSlideId } = state
+
+  const surfaces = useMemo(
+    () => project.slides.find(s => s.id === selectedSlideId)?.surfaces ?? [],
+    [project.slides, selectedSlideId]
+  )
+
+  // ── WebGL setup (runs once) ─────────────────────────────────────────────────
   useEffect(() => {
     const container = containerRef.current!
 
-    // WebGL renderer
     const renderer = new THREE.WebGLRenderer({ antialias: false })
     renderer.setPixelRatio(window.devicePixelRatio)
     renderer.setSize(container.clientWidth, container.clientHeight)
@@ -199,7 +211,13 @@ export default function Canvas() {
     const mesh = new THREE.Mesh(geometry, material)
     scene.add(mesh)
 
-    // Detections accumulate between frames, flushed on each frame event
+    const surfaceGroup = new THREE.Group()
+    scene.add(surfaceGroup)
+    surfaceGroupRef.current = surfaceGroup
+
+    const render = () => renderer.render(scene, camera)
+    renderRef.current = render
+
     let pendingHands: Hand[] = []
     let pendingFaces: Landmark[][] = []
 
@@ -211,7 +229,7 @@ export default function Canvas() {
       renderer.setSize(w, h)
       overlay.width = w
       overlay.height = h
-      renderer.render(scene, camera)
+      render()
     }
 
     function ensureTexture(w: number, h: number) {
@@ -241,7 +259,6 @@ export default function Canvas() {
       if (event.type !== 'frame') return
       ensureTexture(event.width, event.height)
 
-      // Copy RGB24 → RGBA32 into the reused buffer
       if (event.data.byteLength === frameW * frameH * 3) {
         const src = new Uint8Array(event.data)
         for (let i = 0; i < frameW * frameH; i++) {
@@ -253,9 +270,8 @@ export default function Canvas() {
         texture.needsUpdate = true
       }
 
-      renderer.render(scene, camera)
+      render()
 
-      // Flush overlay: clear then redraw buffered detections
       const { clientWidth: cw, clientHeight: ch } = container
       ctx.clearRect(0, 0, cw, ch)
       const r = frameRect(cw, ch, frameW, frameH)
@@ -277,6 +293,22 @@ export default function Canvas() {
       container.removeChild(overlay)
     }
   }, [])
+
+  // ── Surface meshes (rebuilt whenever the active slide's surfaces change) ────
+  useEffect(() => {
+    const group = surfaceGroupRef.current
+    if (!group) return
+
+    surfaces.forEach((surface, i) => group.add(buildSurfaceMesh(surface, i)))
+    renderRef.current()
+
+    return () => {
+      group.traverse(child => {
+        if (child instanceof THREE.Mesh) disposeSurfaceMesh(child)
+      })
+      group.clear()
+    }
+  }, [surfaces])
 
   return <div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }} />
 }

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -130,6 +130,7 @@ html, body, #root {
 
 .stage-canvas {
   aspect-ratio: 16 / 9;
+  width: 100%;
   max-width: 100%;
   max-height: 100%;
   position: relative;

--- a/packages/ts/lights/src/homography.ts
+++ b/packages/ts/lights/src/homography.ts
@@ -1,0 +1,126 @@
+import * as THREE from 'three'
+import type { Surface } from './model/types'
+
+// ── Shaders ──────────────────────────────────────────────────────────────────
+
+const vertexShader = /* glsl */`
+attribute float aW;
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  // position is pre-multiplied by W; setting gl_Position.w = aW causes the GPU
+  // to perspective-divide back to the correct NDC coords and to interpolate vUv
+  // perspective-correctly across the quad (the "W trick").
+  gl_Position = vec4(position.xy, 0.0, aW);
+}
+`
+
+const fragmentShader = /* glsl */`
+varying vec2 vUv;
+uniform vec3 uColor;
+void main() {
+  float check = mod(floor(vUv.x * 6.0) + floor(vUv.y * 6.0), 2.0);
+  vec3 col = mix(uColor * 0.55, uColor, check);
+  gl_FragColor = vec4(col, 0.8);
+}
+`
+
+// ── Math ─────────────────────────────────────────────────────────────────────
+
+function gaussianElim(A: number[][], b: number[]): number[] {
+  const n = A.length
+  const M = A.map((row, i) => [...row, b[i]])
+  for (let col = 0; col < n; col++) {
+    let pivot = col
+    for (let row = col + 1; row < n; row++) {
+      if (Math.abs(M[row][col]) > Math.abs(M[pivot][col])) pivot = row
+    }
+    ;[M[col], M[pivot]] = [M[pivot], M[col]]
+    for (let row = col + 1; row < n; row++) {
+      const f = M[row][col] / M[col][col]
+      for (let k = col; k <= n; k++) M[row][k] -= f * M[col][k]
+    }
+  }
+  const x = new Array(n).fill(0)
+  for (let i = n - 1; i >= 0; i--) {
+    x[i] = M[i][n]
+    for (let j = i + 1; j < n; j++) x[i] -= M[i][j] * x[j]
+    x[i] /= M[i][i]
+  }
+  return x
+}
+
+// 3×3 homography (row-major, h22=1) mapping src[i] → dst[i] via DLT.
+function computeHomography(src: [number, number][], dst: [number, number][]): number[] {
+  const A: number[][] = []
+  const b: number[] = []
+  for (let i = 0; i < 4; i++) {
+    const [u, v] = src[i]
+    const [x, y] = dst[i]
+    A.push([u, v, 1, 0, 0, 0, -x * u, -x * v])
+    b.push(x)
+    A.push([0, 0, 0, u, v, 1, -y * u, -y * v])
+    b.push(y)
+  }
+  return [...gaussianElim(A, b), 1]
+}
+
+// ── Mesh builder ─────────────────────────────────────────────────────────────
+
+// UV corners matching outputPolygon corner order: TL, TR, BR, BL
+const SRC_UVS: [number, number][] = [[0, 0], [1, 0], [1, 1], [0, 1]]
+
+const COLORS: [number, number, number][] = [
+  [0.38, 0.65, 0.98],
+  [0.37, 0.80, 0.60],
+  [0.98, 0.60, 0.38],
+  [0.80, 0.37, 0.74],
+  [0.98, 0.85, 0.37],
+]
+
+export function buildSurfaceMesh(surface: Surface, colorIdx: number): THREE.Mesh {
+  // Convert normalized stage [0,1] coords to NDC [-1,1]; flip Y (stage Y↓, NDC Y↑)
+  const dst: [number, number][] = surface.outputPolygon.map(p => [
+    p.x * 2 - 1,
+    1 - p.y * 2,
+  ])
+
+  const H = computeHomography(SRC_UVS, dst)
+
+  const positions = new Float32Array(12)
+  const uvs = new Float32Array(8)
+  const ws = new Float32Array(4)
+
+  SRC_UVS.forEach(([u, v], i) => {
+    const w = H[6] * u + H[7] * v + H[8]
+    positions[i * 3]     = dst[i][0] * w
+    positions[i * 3 + 1] = dst[i][1] * w
+    positions[i * 3 + 2] = 0
+    uvs[i * 2]     = u
+    uvs[i * 2 + 1] = v
+    ws[i] = w
+  })
+
+  const geo = new THREE.BufferGeometry()
+  geo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  geo.setAttribute('uv',       new THREE.BufferAttribute(uvs, 2))
+  geo.setAttribute('aW',       new THREE.BufferAttribute(ws, 1))
+  geo.setIndex([0, 1, 2, 0, 2, 3])
+
+  const color = COLORS[colorIdx % COLORS.length]
+  const material = new THREE.ShaderMaterial({
+    vertexShader,
+    fragmentShader,
+    uniforms: { uColor: { value: new THREE.Vector3(...color) } },
+    transparent: true,
+    side: THREE.DoubleSide,
+    depthTest: false,
+  })
+
+  return new THREE.Mesh(geo, material)
+}
+
+export function disposeSurfaceMesh(mesh: THREE.Mesh): void {
+  mesh.geometry.dispose()
+  ;(mesh.material as THREE.Material).dispose()
+}


### PR DESCRIPTION
Adds DLT-based homography computation and a W-trick vertex shader that perspective-warps surfaces onto the stage canvas. Canvas now rebuilds surface meshes from project context whenever the active slide changes. Also fixes stage canvas collapsing to 0x0 by adding width: 100% so the aspect-ratio constraint has an anchor.