### PR TITLE
feat(lights): surface mode — flat local editor (#18)

### DIFF
--- a/packages/ts/lights/src/App.tsx
+++ b/packages/ts/lights/src/App.tsx
@@ -2,10 +2,14 @@ import { useEffect, useState } from 'react'
 import Canvas from './Canvas'
 import SlidePanel from './SlidePanel'
 import StageOverlay from './StageOverlay'
+import SurfaceCanvas from './SurfaceCanvas'
 import SurfacePanel from './SurfacePanel'
+import { useProject } from './model/ProjectContext'
 
 export default function App() {
   const [status, setStatus] = useState<'running' | 'stopped' | 'error'>('stopped')
+  const { state } = useProject()
+  const inSurfaceMode = state.selectedSurfaceId !== null
 
   useEffect(() => {
     return window.lights.onEvent((event) => {
@@ -17,10 +21,14 @@ export default function App() {
     <div className="app">
       <SlidePanel />
       <div className="stage-area">
-        <div className="stage-canvas">
-          <Canvas />
-          <StageOverlay />
-        </div>
+        {inSurfaceMode ? (
+          <SurfaceCanvas />
+        ) : (
+          <div className="stage-canvas">
+            <Canvas />
+            <StageOverlay />
+          </div>
+        )}
         <span className="status">{status}</span>
       </div>
       <SurfacePanel />

--- a/packages/ts/lights/src/SurfaceCanvas.tsx
+++ b/packages/ts/lights/src/SurfaceCanvas.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react'
+import { useProject } from './model/ProjectContext'
+import type { Point } from './model/types'
+
+function surfaceAspectRatio(polygon: [Point, Point, Point, Point]): number {
+  const stageAr = 16 / 9
+  function dist(a: Point, b: Point) {
+    const dx = (a.x - b.x) * stageAr
+    const dy = a.y - b.y
+    return Math.sqrt(dx * dx + dy * dy)
+  }
+  const w = (dist(polygon[0], polygon[1]) + dist(polygon[3], polygon[2])) / 2
+  const h = (dist(polygon[0], polygon[3]) + dist(polygon[1], polygon[2])) / 2
+  return h > 0 ? w / h : 16 / 9
+}
+
+export default function SurfaceCanvas() {
+  const { state, dispatch } = useProject()
+  const { project, selectedSlideId, selectedSurfaceId } = state
+
+  const slide = project.slides.find(s => s.id === selectedSlideId)
+  const surface = slide?.surfaces.find(s => s.id === selectedSurfaceId)
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') dispatch({ type: 'surface:select', surfaceId: null })
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [dispatch])
+
+  if (!surface || !selectedSlideId) return null
+
+  const solidLayer = surface.layers.find(l => l.type === 'solid')
+  const fillColor = solidLayer?.type === 'solid' ? solidLayer.color : '#111122'
+  const ar = surfaceAspectRatio(surface.outputPolygon)
+
+  return (
+    <div className="surface-mode">
+      <div className="surface-mode-header">
+        <button
+          className="back-btn"
+          onClick={() => dispatch({ type: 'surface:select', surfaceId: null })}
+        >
+          ← Stage
+        </button>
+        <span className="surface-mode-name">{surface.name}</span>
+      </div>
+      <div className="surface-mode-canvas-area">
+        <div className="surface-mode-canvas" style={{ aspectRatio: ar, background: fillColor }} />
+      </div>
+    </div>
+  )
+}

--- a/packages/ts/lights/src/SurfacePanel.tsx
+++ b/packages/ts/lights/src/SurfacePanel.tsx
@@ -1,4 +1,5 @@
 import { useProject } from './model/ProjectContext'
+import type { SolidLayer } from './model/types'
 
 export default function SurfacePanel() {
   const { state, dispatch } = useProject()
@@ -6,7 +7,38 @@ export default function SurfacePanel() {
 
   const slide = project.slides.find(s => s.id === selectedSlideId)
   const surfaces = slide?.surfaces ?? []
+  const surface = surfaces.find(s => s.id === selectedSurfaceId)
 
+  // ── Surface mode: show editor for the selected surface ──────────────────────
+  if (selectedSurfaceId && surface && selectedSlideId) {
+    const solidLayer = surface.layers.find((l): l is SolidLayer => l.type === 'solid')
+
+    function setColor(color: string) {
+      const layers = solidLayer
+        ? surface!.layers.map(l => l.id === solidLayer!.id ? { ...solidLayer!, color } : l)
+        : [{ id: crypto.randomUUID(), type: 'solid' as const, color }, ...surface!.layers]
+      dispatch({ type: 'surface:update', slideId: selectedSlideId!, surface: { ...surface!, layers } })
+    }
+
+    return (
+      <aside className="surface-panel">
+        <div className="surface-panel-header">
+          <span>{surface.name}</span>
+        </div>
+        <div className="surface-editor">
+          <label className="surface-editor-label">Fill</label>
+          <input
+            type="color"
+            className="surface-editor-color"
+            value={solidLayer?.color ?? '#111122'}
+            onChange={e => setColor(e.target.value)}
+          />
+        </div>
+      </aside>
+    )
+  }
+
+  // ── Stage mode: show surface list ───────────────────────────────────────────
   return (
     <aside className="surface-panel">
       <div className="surface-panel-header">
@@ -28,19 +60,19 @@ export default function SurfacePanel() {
         <p className="panel-empty">No surfaces</p>
       ) : (
         <div className="surface-list">
-          {surfaces.map(surface => (
+          {surfaces.map(s => (
             <div
-              key={surface.id}
-              className={`surface-item${surface.id === selectedSurfaceId ? ' selected' : ''}`}
-              onClick={() => dispatch({ type: 'surface:select', surfaceId: surface.id })}
+              key={s.id}
+              className={`surface-item${s.id === selectedSurfaceId ? ' selected' : ''}`}
+              onClick={() => dispatch({ type: 'surface:select', surfaceId: s.id })}
             >
-              <span className="surface-name">{surface.name}</span>
+              <span className="surface-name">{s.name}</span>
               <button
                 className="icon-btn surface-remove"
                 title="Remove surface"
                 onClick={e => {
                   e.stopPropagation()
-                  dispatch({ type: 'surface:remove', slideId: selectedSlideId, surfaceId: surface.id })
+                  dispatch({ type: 'surface:remove', slideId: selectedSlideId, surfaceId: s.id })
                 }}
               >
                 ×

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -216,6 +216,85 @@ html, body, #root {
   color: #ef4444 !important;
 }
 
+/* ── Surface mode ────────────────────────────────────────────────────────── */
+
+.surface-mode {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.surface-mode-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid #222;
+  flex-shrink: 0;
+}
+
+.back-btn {
+  background: none;
+  border: 1px solid #2a2a2a;
+  color: #777;
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.back-btn:hover {
+  border-color: #444;
+  color: #ccc;
+}
+
+.surface-mode-name {
+  font-size: 12px;
+  color: #555;
+}
+
+.surface-mode-canvas-area {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #161616;
+  overflow: hidden;
+  padding: 24px;
+}
+
+.surface-mode-canvas {
+  width: 100%;
+  max-height: 100%;
+}
+
+/* ── Surface editor (right panel in surface mode) ────────────────────────── */
+
+.surface-editor {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.surface-editor-label {
+  font-size: 10px;
+  color: #555;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.surface-editor-color {
+  width: 100%;
+  height: 32px;
+  border: 1px solid #2a2a2a;
+  border-radius: 3px;
+  background: none;
+  cursor: pointer;
+  padding: 2px;
+}
+
 /* ── Status pill ─────────────────────────────────────────────────────────── */
 
 .status {

--- a/packages/ts/lights/src/homography.ts
+++ b/packages/ts/lights/src/homography.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import type { Surface } from './model/types'
+import type { SolidLayer, Surface } from './model/types'
 
 // ── Shaders ──────────────────────────────────────────────────────────────────
 
@@ -15,7 +15,7 @@ void main() {
 }
 `
 
-const fragmentShader = /* glsl */`
+const fragmentShaderChecker = /* glsl */`
 varying vec2 vUv;
 uniform vec3 uColor;
 void main() {
@@ -24,6 +24,19 @@ void main() {
   gl_FragColor = vec4(col, 0.8);
 }
 `
+
+const fragmentShaderSolid = /* glsl */`
+varying vec2 vUv;
+uniform vec3 uColor;
+void main() {
+  gl_FragColor = vec4(uColor, 1.0);
+}
+`
+
+function hexToVec3(hex: string): THREE.Vector3 {
+  const n = parseInt(hex.replace('#', ''), 16)
+  return new THREE.Vector3(((n >> 16) & 255) / 255, ((n >> 8) & 255) / 255, (n & 255) / 255)
+}
 
 // ── Math ─────────────────────────────────────────────────────────────────────
 
@@ -107,15 +120,24 @@ export function buildSurfaceMesh(surface: Surface, colorIdx: number): THREE.Mesh
   geo.setAttribute('aW',       new THREE.BufferAttribute(ws, 1))
   geo.setIndex([0, 1, 2, 0, 2, 3])
 
-  const color = COLORS[colorIdx % COLORS.length]
-  const material = new THREE.ShaderMaterial({
-    vertexShader,
-    fragmentShader,
-    uniforms: { uColor: { value: new THREE.Vector3(...color) } },
-    transparent: true,
-    side: THREE.DoubleSide,
-    depthTest: false,
-  })
+  const solidLayer = surface.layers.find((l): l is SolidLayer => l.type === 'solid')
+  const material = solidLayer
+    ? new THREE.ShaderMaterial({
+        vertexShader,
+        fragmentShader: fragmentShaderSolid,
+        uniforms: { uColor: { value: hexToVec3(solidLayer.color) } },
+        transparent: false,
+        side: THREE.DoubleSide,
+        depthTest: false,
+      })
+    : new THREE.ShaderMaterial({
+        vertexShader,
+        fragmentShader: fragmentShaderChecker,
+        uniforms: { uColor: { value: new THREE.Vector3(...COLORS[colorIdx % COLORS.length]) } },
+        transparent: true,
+        side: THREE.DoubleSide,
+        depthTest: false,
+      })
 
   return new THREE.Mesh(geo, material)
 }

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -4,8 +4,9 @@ export type { Point, GraphConfig }
 
 export type Polygon = Point[]
 
-// Stubs — filled out in M3 (layers) and M4 (reactions)
-export interface Layer { id: string; type: string }
+export interface SolidLayer { id: string; type: 'solid'; color: string }
+export type Layer = SolidLayer  // union grows in M3
+
 export interface Reaction { id: string }
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface Calibration {} // populated by M5 (camera-to-projector mapping)


### PR DESCRIPTION
Clicking a surface enters surface mode: a flat canvas showing the surface's local space with a colour picker in the right panel. Back button or Escape returns to stage mode.

Introduces SolidLayer as the first concrete layer type. The stage canvas renders the chosen fill colour as a warped quad; surfaces with no fill keep the checkerboard placeholder.