### PR TITLE
feat(lights): projector output window shell (#23)

### DIFF
--- a/packages/ts/lights/electron/main.ts
+++ b/packages/ts/lights/electron/main.ts
@@ -10,6 +10,8 @@ process.env.APP_ROOT = path.join(__dirname, '..')
 const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL
 
 let win: BrowserWindow | null = null
+let outputWin: BrowserWindow | null = null
+let lastSlide: unknown = null
 let stubInterval: ReturnType<typeof setInterval> | null = null
 
 function emit(event: GraphEvent) {
@@ -62,6 +64,11 @@ function stopStubGraph() {
   emit({ type: 'graph:status', status: 'stopped' })
 }
 
+ipcMain.on('output:slide', (_event, slide: unknown) => {
+  lastSlide = slide
+  outputWin?.webContents.send('output:render', slide)
+})
+
 ipcMain.on('graph:command', (_event, cmd: GraphCommand) => {
   switch (cmd.type) {
     case 'slide:activate':
@@ -72,6 +79,31 @@ ipcMain.on('graph:command', (_event, cmd: GraphCommand) => {
       break
   }
 })
+
+function createOutputWindow() {
+  outputWin = new BrowserWindow({
+    width: 800,
+    height: 450,
+    backgroundColor: '#000000',
+    title: 'Lights — Output',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.mjs'),
+      contextIsolation: true,
+    },
+  })
+
+  outputWin.on('closed', () => { outputWin = null })
+
+  outputWin.webContents.on('did-finish-load', () => {
+    if (lastSlide !== null) outputWin?.webContents.send('output:render', lastSlide)
+  })
+
+  if (DEV_SERVER_URL) {
+    outputWin.loadURL(`${DEV_SERVER_URL}?output=1`)
+  } else {
+    outputWin.loadFile(path.join(process.env.APP_ROOT!, 'dist/index.html'), { query: { output: '1' } })
+  }
+}
 
 function createWindow() {
   win = new BrowserWindow({
@@ -99,7 +131,10 @@ function createWindow() {
   }
 }
 
-app.whenReady().then(createWindow)
+app.whenReady().then(() => {
+  createWindow()
+  createOutputWindow()
+})
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()

--- a/packages/ts/lights/electron/preload.ts
+++ b/packages/ts/lights/electron/preload.ts
@@ -8,6 +8,12 @@ const bridge: LightsBridge = {
     ipcRenderer.on('graph:event', listener)
     return () => ipcRenderer.off('graph:event', listener)
   },
+  sendSlide: (slide: unknown) => ipcRenderer.send('output:slide', slide),
+  onOutputRender: (handler: (slide: unknown) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, slide: unknown) => handler(slide)
+    ipcRenderer.on('output:render', listener)
+    return () => ipcRenderer.off('output:render', listener)
+  },
 }
 
 contextBridge.exposeInMainWorld('lights', bridge)

--- a/packages/ts/lights/src/OutputApp.tsx
+++ b/packages/ts/lights/src/OutputApp.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react'
+import * as THREE from 'three'
+import { buildSurfaceMesh, disposeSurfaceMesh } from './homography'
+import type { Slide } from './model/types'
+
+export default function OutputApp() {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = containerRef.current!
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true })
+    renderer.setPixelRatio(window.devicePixelRatio)
+    renderer.setClearColor(0x000000, 1)
+    container.appendChild(renderer.domElement)
+
+    const scene = new THREE.Scene()
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+
+    const surfaceGroup = new THREE.Group()
+    scene.add(surfaceGroup)
+
+    function render() { renderer.render(scene, camera) }
+
+    function renderSlide(slide: Slide) {
+      surfaceGroup.traverse(child => {
+        if (child instanceof THREE.Mesh) disposeSurfaceMesh(child)
+      })
+      surfaceGroup.clear()
+      slide.surfaces.forEach((surface, i) => {
+        // Only render surfaces that have real content — checkerboard stays editor-only
+        if (surface.layers.some(l => l.type === 'solid')) {
+          surfaceGroup.add(buildSurfaceMesh(surface, i))
+        }
+      })
+      render()
+    }
+
+    const off = window.lights.onOutputRender(data => renderSlide(data as Slide))
+
+    function updateLayout() {
+      const { clientWidth: w, clientHeight: h } = container
+      renderer.setSize(w, h)
+      render()
+    }
+
+    const observer = new ResizeObserver(updateLayout)
+    observer.observe(container)
+    updateLayout()
+
+    return () => {
+      off()
+      observer.disconnect()
+      surfaceGroup.traverse(child => {
+        if (child instanceof THREE.Mesh) disposeSurfaceMesh(child)
+      })
+      renderer.dispose()
+      container.removeChild(renderer.domElement)
+    }
+  }, [])
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: '100vw', height: '100vh', overflow: 'hidden', background: '#000' }}
+    />
+  )
+}

--- a/packages/ts/lights/src/ipc/types.ts
+++ b/packages/ts/lights/src/ipc/types.ts
@@ -38,6 +38,8 @@ export type GraphEvent =
 export interface LightsBridge {
   sendCommand: (cmd: GraphCommand) => void
   onEvent: (handler: (event: GraphEvent) => void) => () => void
+  sendSlide: (slide: unknown) => void
+  onOutputRender: (handler: (slide: unknown) => void) => () => void
 }
 
 declare global {

--- a/packages/ts/lights/src/main.tsx
+++ b/packages/ts/lights/src/main.tsx
@@ -2,12 +2,19 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './app.css'
 import App from './App'
+import OutputApp from './OutputApp'
 import { ProjectProvider } from './model/ProjectContext'
+
+const isOutput = new URLSearchParams(window.location.search).has('output')
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ProjectProvider>
-      <App />
-    </ProjectProvider>
+    {isOutput ? (
+      <OutputApp />
+    ) : (
+      <ProjectProvider>
+        <App />
+      </ProjectProvider>
+    )}
   </StrictMode>
 )

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -146,6 +146,7 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
       if (surface.areaOfInterest) aois[surface.id] = surface.areaOfInterest
     }
     window.lights.sendCommand({ type: 'slide:activate', config: slide.graphConfig, aois })
+    window.lights.sendSlide(slide)
   }, [state.selectedSlideId, state.project.slides])
 
   return <ProjectContext.Provider value={{ state, dispatch }}>{children}</ProjectContext.Provider>


### PR DESCRIPTION
Opens a second BrowserWindow on launch (800×450, no graph chrome) that serves as the projection output. The editor pushes the active slide to main via IPC whenever it changes; main forwards it to the output window which re-renders surfaces with their real fill colours. Checkerboard placeholder is editor-only — the output window shows black for surfaces with no content.