### PR TITLE
feat(layers): layer panel — stack, visibility, drag-to-reorder (#27)

### DIFF
--- a/packages/ts/lights/src/OutputApp.tsx
+++ b/packages/ts/lights/src/OutputApp.tsx
@@ -29,7 +29,7 @@ export default function OutputApp() {
       surfaceGroup.clear()
       slide.surfaces.forEach((surface, i) => {
         // Only render surfaces that have real content — checkerboard stays editor-only
-        if (surface.layers.some(l => l.type === 'solid')) {
+        if (surface.layers.some(l => l.type === 'solid' && l.visible)) {
           surfaceGroup.add(buildSurfaceMesh(surface, i))
         }
       })

--- a/packages/ts/lights/src/SurfaceCanvas.tsx
+++ b/packages/ts/lights/src/SurfaceCanvas.tsx
@@ -52,7 +52,7 @@ export default function SurfaceCanvas() {
 
   if (!surface || !selectedSlideId) return null
 
-  const solidLayer = surface.layers.find(l => l.type === 'solid')
+  const solidLayer = surface.layers.find(l => l.type === 'solid' && l.visible)
   const fillColor = solidLayer?.type === 'solid' ? solidLayer.color : '#111122'
   const ar = surfaceAspectRatio(surface.outputPolygon)
 

--- a/packages/ts/lights/src/SurfacePanel.tsx
+++ b/packages/ts/lights/src/SurfacePanel.tsx
@@ -1,44 +1,70 @@
+import { useState } from 'react'
 import { useProject } from './model/ProjectContext'
 import type { SolidLayer } from './model/types'
 
 export default function SurfacePanel() {
   const { state, dispatch } = useProject()
-  const { project, selectedSlideId, selectedSurfaceId, surfaceMode } = state
+  const { project, selectedSlideId, selectedSurfaceId, selectedLayerId, surfaceMode } = state
 
   const slide = project.slides.find(s => s.id === selectedSlideId)
   const surfaces = slide?.surfaces ?? []
   const surface = surfaces.find(s => s.id === selectedSurfaceId)
 
-  // ── Surface mode: show editor for the selected surface ──────────────────────
+  // ── Surface mode: layer panel ───────────────────────────────────────────────
   if (surfaceMode && surface && selectedSlideId) {
-    const solidLayer = surface.layers.find((l): l is SolidLayer => l.type === 'solid')
+    const selectedLayer = surface.layers.find(l => l.id === selectedLayerId)
+    const solidLayer = selectedLayer?.type === 'solid' ? (selectedLayer as SolidLayer) : undefined
+
+    function addLayer() {
+      dispatch({ type: 'layer:add', slideId: selectedSlideId!, surfaceId: surface!.id })
+    }
+
+    function removeLayer(layerId: string) {
+      dispatch({ type: 'layer:remove', slideId: selectedSlideId!, surfaceId: surface!.id, layerId })
+    }
+
+    function toggleVisibility(layerId: string) {
+      dispatch({ type: 'layer:toggle-visibility', slideId: selectedSlideId!, surfaceId: surface!.id, layerId })
+    }
 
     function setColor(color: string) {
-      const layers = solidLayer
-        ? surface!.layers.map(l => l.id === solidLayer!.id ? { ...solidLayer!, color } : l)
-        : [{ id: crypto.randomUUID(), type: 'solid' as const, color }, ...surface!.layers]
-      dispatch({ type: 'surface:update', slideId: selectedSlideId!, surface: { ...surface!, layers } })
+      if (!solidLayer) return
+      dispatch({ type: 'layer:update', slideId: selectedSlideId!, surfaceId: surface!.id, layer: { ...solidLayer, color } })
     }
 
     return (
       <aside className="surface-panel">
         <div className="surface-panel-header">
-          <span>{surface.name}</span>
+          <button className="back-btn" onClick={() => dispatch({ type: 'surface:exit' })}>← Stage</button>
+          <span className="surface-mode-name">{surface.name}</span>
         </div>
-        <div className="surface-editor">
-          <label className="surface-editor-label">Fill</label>
-          <input
-            type="color"
-            className="surface-editor-color"
-            value={solidLayer?.color ?? '#111122'}
-            onChange={e => setColor(e.target.value)}
-          />
-        </div>
+
+        <LayerList
+          surface={surface}
+          selectedLayerId={selectedLayerId}
+          onSelect={id => dispatch({ type: 'layer:select', layerId: id })}
+          onToggleVisibility={toggleVisibility}
+          onRemove={removeLayer}
+          onReorder={ids => dispatch({ type: 'layer:reorder', slideId: selectedSlideId!, surfaceId: surface!.id, layerIds: ids })}
+          onAdd={addLayer}
+        />
+
+        {solidLayer && (
+          <div className="surface-editor">
+            <label className="surface-editor-label">Fill</label>
+            <input
+              type="color"
+              className="surface-editor-color"
+              value={solidLayer.color}
+              onChange={e => setColor(e.target.value)}
+            />
+          </div>
+        )}
       </aside>
     )
   }
 
-  // ── Stage mode: show surface list ───────────────────────────────────────────
+  // ── Stage mode: surface list ────────────────────────────────────────────────
   return (
     <aside className="surface-panel">
       <div className="surface-panel-header">
@@ -72,7 +98,7 @@ export default function SurfacePanel() {
                 title="Remove surface"
                 onClick={e => {
                   e.stopPropagation()
-                  dispatch({ type: 'surface:remove', slideId: selectedSlideId, surfaceId: s.id })
+                  dispatch({ type: 'surface:remove', slideId: selectedSlideId!, surfaceId: s.id })
                 }}
               >
                 ×
@@ -82,5 +108,100 @@ export default function SurfacePanel() {
         </div>
       )}
     </aside>
+  )
+}
+
+// ── LayerList ─────────────────────────────────────────────────────────────────
+
+interface LayerListProps {
+  surface: { layers: import('./model/types').Layer[] }
+  selectedLayerId: string | null
+  onSelect: (id: string) => void
+  onToggleVisibility: (id: string) => void
+  onRemove: (id: string) => void
+  onReorder: (ids: string[]) => void
+  onAdd: () => void
+}
+
+function LayerList({ surface, selectedLayerId, onSelect, onToggleVisibility, onRemove, onReorder, onAdd }: LayerListProps) {
+  const [dragIdx, setDragIdx] = useState<number | null>(null)
+  const [dropIdx, setDropIdx] = useState<number | null>(null)
+
+  function handleDragStart(idx: number) {
+    setDragIdx(idx)
+  }
+
+  function handleDragOver(e: React.DragEvent, idx: number) {
+    e.preventDefault()
+    setDropIdx(idx)
+  }
+
+  function handleDrop(targetIdx: number) {
+    if (dragIdx !== null && dragIdx !== targetIdx) {
+      const reordered = [...surface.layers]
+      const [moved] = reordered.splice(dragIdx, 1)
+      reordered.splice(targetIdx, 0, moved)
+      onReorder(reordered.map(l => l.id))
+    }
+    setDragIdx(null)
+    setDropIdx(null)
+  }
+
+  function handleDragEnd() {
+    setDragIdx(null)
+    setDropIdx(null)
+  }
+
+  return (
+    <div className="layer-panel">
+      <div className="layer-panel-header">
+        <span>Layers</span>
+        <button className="icon-btn" title="Add layer" onClick={onAdd}>+</button>
+      </div>
+
+      {surface.layers.length === 0 ? (
+        <p className="panel-empty">No layers</p>
+      ) : (
+        <div className="layer-list">
+          {surface.layers.map((layer, idx) => (
+            <div
+              key={layer.id}
+              className={[
+                'layer-item',
+                layer.id === selectedLayerId ? 'selected' : '',
+                dragIdx === idx ? 'dragging' : '',
+                dropIdx === idx && dragIdx !== idx ? 'drop-target' : '',
+              ].filter(Boolean).join(' ')}
+              draggable
+              onDragStart={() => handleDragStart(idx)}
+              onDragOver={e => handleDragOver(e, idx)}
+              onDrop={() => handleDrop(idx)}
+              onDragEnd={handleDragEnd}
+              onClick={() => onSelect(layer.id)}
+            >
+              <span className="layer-drag-handle">⠿</span>
+              <button
+                className="icon-btn layer-visibility"
+                title={layer.visible ? 'Hide' : 'Show'}
+                onClick={e => { e.stopPropagation(); onToggleVisibility(layer.id) }}
+              >
+                {layer.visible ? '●' : '○'}
+              </button>
+              <span className="layer-name">{layer.name}</span>
+              {layer.type === 'solid' && (
+                <span className="layer-color-swatch" style={{ background: (layer as SolidLayer).color }} />
+              )}
+              <button
+                className="icon-btn layer-remove"
+                title="Remove layer"
+                onClick={e => { e.stopPropagation(); onRemove(layer.id) }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -269,6 +269,112 @@ html, body, #root {
   flex-shrink: 0;
 }
 
+/* ── Layer panel ─────────────────────────────────────────────────────────── */
+
+.layer-panel {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid #1a1a1a;
+}
+
+.layer-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px 6px;
+  font-size: 10px;
+  color: #444;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.layer-list {
+  overflow-y: auto;
+  padding: 4px 8px;
+  max-height: 200px;
+}
+
+.layer-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #666;
+  user-select: none;
+}
+
+.layer-item:hover {
+  background: #1a1a1a;
+  color: #ccc;
+}
+
+.layer-item.selected {
+  background: #1a2744;
+  color: #60a5fa;
+}
+
+.layer-item.dragging {
+  opacity: 0.4;
+}
+
+.layer-item.drop-target {
+  border-top: 2px solid #60a5fa;
+}
+
+.layer-drag-handle {
+  color: #333;
+  cursor: grab;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.layer-item:hover .layer-drag-handle {
+  color: #555;
+}
+
+.layer-visibility {
+  color: #444;
+  flex-shrink: 0;
+}
+
+.layer-item.selected .layer-visibility {
+  color: #5090d0;
+}
+
+.layer-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.layer-color-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  border: 1px solid #333;
+  flex-shrink: 0;
+}
+
+.layer-remove {
+  opacity: 0;
+  color: #555;
+  flex-shrink: 0;
+}
+
+.layer-item:hover .layer-remove,
+.layer-item.selected .layer-remove {
+  opacity: 1;
+}
+
+.layer-remove:hover {
+  color: #ef4444 !important;
+}
+
 /* ── Surface editor (right panel in surface mode) ────────────────────────── */
 
 .surface-editor {

--- a/packages/ts/lights/src/homography.ts
+++ b/packages/ts/lights/src/homography.ts
@@ -120,7 +120,7 @@ export function buildSurfaceMesh(surface: Surface, colorIdx: number): THREE.Mesh
   geo.setAttribute('aW',       new THREE.BufferAttribute(ws, 1))
   geo.setIndex([0, 1, 2, 0, 2, 3])
 
-  const solidLayer = surface.layers.find((l): l is SolidLayer => l.type === 'solid')
+  const solidLayer = surface.layers.find((l): l is SolidLayer => l.type === 'solid' && l.visible)
   const material = solidLayer
     ? new THREE.ShaderMaterial({
         vertexShader,

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useReducer } from 'react'
 import type { Dispatch, ReactNode } from 'react'
-import type { Project, Slide, Surface } from './types'
+import type { Layer, Project, Slide, Surface } from './types'
 
 // ── State ────────────────────────────────────────────────────────────────────
 
@@ -8,6 +8,7 @@ export interface ProjectState {
   project: Project
   selectedSlideId: string | null
   selectedSurfaceId: string | null
+  selectedLayerId: string | null
   surfaceMode: boolean  // true = flat local editor open
 }
 
@@ -15,6 +16,7 @@ const initial: ProjectState = {
   project: { slides: [], calibration: {} },
   selectedSlideId: null,
   selectedSurfaceId: null,
+  selectedLayerId: null,
   surfaceMode: false,
 }
 
@@ -30,8 +32,33 @@ export type ProjectAction =
   | { type: 'surface:select'; surfaceId: string | null }
   | { type: 'surface:enter' }   // double-click → open flat editor
   | { type: 'surface:exit' }    // back / Escape → return to stage, keep selection
+  | { type: 'layer:add'; slideId: string; surfaceId: string }
+  | { type: 'layer:remove'; slideId: string; surfaceId: string; layerId: string }
+  | { type: 'layer:update'; slideId: string; surfaceId: string; layer: Layer }
+  | { type: 'layer:reorder'; slideId: string; surfaceId: string; layerIds: string[] }
+  | { type: 'layer:select'; layerId: string | null }
+  | { type: 'layer:toggle-visibility'; slideId: string; surfaceId: string; layerId: string }
 
 // ── Reducer ──────────────────────────────────────────────────────────────────
+
+function patchSurfaceLayers(
+  state: ProjectState,
+  slideId: string,
+  surfaceId: string,
+  fn: (layers: Layer[]) => Layer[]
+): ProjectState {
+  return {
+    ...state,
+    project: {
+      ...state.project,
+      slides: state.project.slides.map(s =>
+        s.id === slideId
+          ? { ...s, surfaces: s.surfaces.map(sf => sf.id === surfaceId ? { ...sf, layers: fn(sf.layers) } : sf) }
+          : s
+      ),
+    },
+  }
+}
 
 function reducer(state: ProjectState, action: ProjectAction): ProjectState {
   const { project } = state
@@ -69,7 +96,7 @@ function reducer(state: ProjectState, action: ProjectAction): ProjectState {
     }
 
     case 'slide:select':
-      return { ...state, selectedSlideId: action.slideId, selectedSurfaceId: null, surfaceMode: false }
+      return { ...state, selectedSlideId: action.slideId, selectedSurfaceId: null, selectedLayerId: null, surfaceMode: false }
 
     case 'surface:add': {
       const surface: Surface = {
@@ -127,14 +154,60 @@ function reducer(state: ProjectState, action: ProjectAction): ProjectState {
     }
 
     case 'surface:select':
-      return { ...state, selectedSurfaceId: action.surfaceId, surfaceMode: false }
+      return { ...state, selectedSurfaceId: action.surfaceId, selectedLayerId: null, surfaceMode: false }
 
     case 'surface:enter':
       if (!state.selectedSurfaceId) return state
       return { ...state, surfaceMode: true }
 
     case 'surface:exit':
-      return { ...state, surfaceMode: false }
+      return { ...state, surfaceMode: false, selectedLayerId: null }
+
+    case 'layer:add': {
+      const slide = project.slides.find(s => s.id === action.slideId)
+      const surface = slide?.surfaces.find(sf => sf.id === action.surfaceId)
+      if (!surface) return state
+      const layer: Layer = {
+        id: crypto.randomUUID(),
+        type: 'solid',
+        name: `Layer ${surface.layers.length + 1}`,
+        visible: true,
+        color: '#111122',
+      }
+      return {
+        ...patchSurfaceLayers(state, action.slideId, action.surfaceId, layers => [layer, ...layers]),
+        selectedLayerId: layer.id,
+      }
+    }
+
+    case 'layer:remove': {
+      const next = patchSurfaceLayers(state, action.slideId, action.surfaceId, layers =>
+        layers.filter(l => l.id !== action.layerId)
+      )
+      return {
+        ...next,
+        selectedLayerId: state.selectedLayerId === action.layerId ? null : state.selectedLayerId,
+      }
+    }
+
+    case 'layer:update':
+      return patchSurfaceLayers(state, action.slideId, action.surfaceId, layers =>
+        layers.map(l => l.id === action.layer.id ? action.layer : l)
+      )
+
+    case 'layer:reorder':
+      return patchSurfaceLayers(state, action.slideId, action.surfaceId, layers => {
+        const map = new Map(layers.map(l => [l.id, l]))
+        return action.layerIds.flatMap(id => (map.has(id) ? [map.get(id)!] : []))
+      })
+
+    case 'layer:select':
+      return { ...state, selectedLayerId: action.layerId }
+
+    case 'layer:toggle-visibility':
+      return patchSurfaceLayers(state, action.slideId, action.surfaceId, layers =>
+        layers.map(l => l.id === action.layerId ? { ...l, visible: !l.visible } : l)
+      )
   }
 }
 

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -4,7 +4,7 @@ export type { Point, GraphConfig }
 
 export type Polygon = Point[]
 
-export interface SolidLayer { id: string; type: 'solid'; color: string }
+export interface SolidLayer { id: string; type: 'solid'; name: string; visible: boolean; color: string }
 export type Layer = SolidLayer  // union grows in M3
 
 export interface Reaction { id: string }


### PR DESCRIPTION
## Summary
- Adds `name` and `visible` fields to `SolidLayer`
- Adds `selectedLayerId` to project state + full layer action set (`layer:add`, `layer:remove`, `layer:update`, `layer:reorder`, `layer:select`, `layer:toggle-visibility`)
- Replaces the simple color picker in surface mode with a proper layer panel: drag-to-reorder, visibility toggle, add/remove
- Color picker now appears below the list only when a solid layer is selected
- Visibility is respected in `SurfaceCanvas`, `Canvas` (homography), and `OutputApp`

## Test plan
- [ ] Enter surface mode (double-click a surface)
- [ ] Add layers with `+`, verify they appear in the stack
- [ ] Select a layer, verify color picker appears and edits that layer
- [ ] Toggle visibility (`●`/`○`), verify canvas background changes
- [ ] Drag layers to reorder, verify order updates
- [ ] Remove a layer with `×`

🤖 Generated with [Claude Code](https://claude.com/claude-code)