### PR TITLE
feat(layers): drag, resize, rotate in surface space + canvas compositor (#28)

### DIFF
--- a/packages/ts/lights/src/OutputApp.tsx
+++ b/packages/ts/lights/src/OutputApp.tsx
@@ -29,7 +29,7 @@ export default function OutputApp() {
       surfaceGroup.clear()
       slide.surfaces.forEach((surface, i) => {
         // Only render surfaces that have real content — checkerboard stays editor-only
-        if (surface.layers.some(l => l.type === 'solid')) {
+        if (surface.layers.some(l => l.type === 'solid' && l.visible)) {
           surfaceGroup.add(buildSurfaceMesh(surface, i))
         }
       })

--- a/packages/ts/lights/src/OutputApp.tsx
+++ b/packages/ts/lights/src/OutputApp.tsx
@@ -28,8 +28,8 @@ export default function OutputApp() {
       })
       surfaceGroup.clear()
       slide.surfaces.forEach((surface, i) => {
-        // Only render surfaces that have real content — checkerboard stays editor-only
-        if (surface.layers.some(l => l.type === 'solid' && l.visible)) {
+        // Skip surfaces with no visible layers — checkerboard stays editor-only
+        if (surface.layers.some(l => l.visible)) {
           surfaceGroup.add(buildSurfaceMesh(surface, i))
         }
       })

--- a/packages/ts/lights/src/SurfaceCanvas.tsx
+++ b/packages/ts/lights/src/SurfaceCanvas.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useProject } from './model/ProjectContext'
-import type { Point } from './model/types'
+import type { Layer, LayerTransform, Point, SolidLayer } from './model/types'
 
 function surfaceAspectRatio(polygon: [Point, Point, Point, Point]): number {
   const stageAr = 16 / 9
@@ -14,21 +14,35 @@ function surfaceAspectRatio(polygon: [Point, Point, Point, Point]): number {
   return h > 0 ? w / h : 16 / 9
 }
 
-// Largest box with aspect ratio `ar` that fits inside `aw × ah`.
 function fitContain(aw: number, ah: number, ar: number) {
   return aw / ah > ar
     ? { w: ah * ar, h: ah }
     : { w: aw, h: aw / ar }
 }
 
+// ── Drag state ────────────────────────────────────────────────────────────────
+
+type Corner = 'tl' | 'tr' | 'br' | 'bl'
+
+type DragKind =
+  | { kind: 'move';   startPx: Point; startT: LayerTransform }
+  | { kind: 'resize'; corner: Corner; startPx: Point; startT: LayerTransform }
+  | { kind: 'rotate'; centerPx: Point; startAngle: number; startRotation: number }
+
+interface ActiveDrag { layerId: string; drag: DragKind; canvasW: number; canvasH: number }
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
 export default function SurfaceCanvas() {
   const { state, dispatch } = useProject()
-  const { project, selectedSlideId, selectedSurfaceId } = state
+  const { project, selectedSlideId, selectedSurfaceId, selectedLayerId } = state
 
   const slide = project.slides.find(s => s.id === selectedSlideId)
   const surface = slide?.surfaces.find(s => s.id === selectedSurfaceId)
 
-  const areaRef = useRef<HTMLDivElement>(null)
+  const areaRef  = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLDivElement>(null)
+  const dragRef  = useRef<ActiveDrag | null>(null)
   const [availableSize, setAvailableSize] = useState({ w: 0, h: 0 })
 
   useEffect(() => {
@@ -52,32 +66,165 @@ export default function SurfaceCanvas() {
 
   if (!surface || !selectedSlideId) return null
 
-  const solidLayer = surface.layers.find(l => l.type === 'solid' && l.visible)
-  const fillColor = solidLayer?.type === 'solid' ? solidLayer.color : '#111122'
   const ar = surfaceAspectRatio(surface.outputPolygon)
-
   const { w: aw, h: ah } = availableSize
   const { w: canvasW, h: canvasH } = aw > 0 && ah > 0 ? fitContain(aw, ah, ar) : { w: 0, h: 0 }
+
+  function toPx(e: React.PointerEvent): Point {
+    const rect = canvasRef.current!.getBoundingClientRect()
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+  }
+
+  function startDrag(e: React.PointerEvent, layerId: string, drag: DragKind) {
+    e.stopPropagation()
+    dragRef.current = { layerId, drag, canvasW, canvasH }
+    canvasRef.current!.setPointerCapture(e.pointerId)
+  }
+
+  function handlePointerMove(e: React.PointerEvent) {
+    const active = dragRef.current
+    if (!active) return
+    const layer = surface!.layers.find(l => l.id === active.layerId)
+    if (!layer) return
+
+    const px = toPx(e)
+    const { drag, canvasW: cw, canvasH: ch } = active
+    let newT: LayerTransform
+
+    if (drag.kind === 'move') {
+      newT = {
+        ...drag.startT,
+        x: drag.startT.x + (px.x - drag.startPx.x) / cw,
+        y: drag.startT.y + (px.y - drag.startPx.y) / ch,
+      }
+    } else if (drag.kind === 'resize') {
+      const { corner, startPx, startT } = drag
+      const dxN = (px.x - startPx.x) / cw
+      const dyN = (px.y - startPx.y) / ch
+      const wSign = corner === 'tl' || corner === 'bl' ? -1 : 1
+      const hSign = corner === 'tl' || corner === 'tr' ? -1 : 1
+      let newW = Math.max(0.02, startT.w + wSign * dxN)
+      let newH = Math.max(0.02, startT.h + hSign * dyN)
+      if (e.shiftKey) {
+        const ratio = startT.w / startT.h
+        if (Math.abs(dxN) >= Math.abs(dyN)) newH = Math.max(0.02, newW / ratio)
+        else newW = Math.max(0.02, newH * ratio)
+      }
+      newT = {
+        ...startT,
+        x: startT.x + (wSign * (newW - startT.w)) / 2,
+        y: startT.y + (hSign * (newH - startT.h)) / 2,
+        w: newW,
+        h: newH,
+      }
+    } else {
+      const { centerPx, startAngle, startRotation } = drag
+      const angle = Math.atan2(px.y - centerPx.y, px.x - centerPx.x) * 180 / Math.PI
+      newT = { ...layer.transform, rotation: startRotation + (angle - startAngle) }
+    }
+
+    dispatch({ type: 'layer:update', slideId: selectedSlideId!, surfaceId: surface!.id, layer: { ...layer, transform: newT } })
+  }
+
+  function handlePointerUp(e: React.PointerEvent) {
+    dragRef.current = null
+    canvasRef.current?.releasePointerCapture(e.pointerId)
+  }
 
   return (
     <div className="surface-mode">
       <div className="surface-mode-header">
-        <button
-          className="back-btn"
-          onClick={() => dispatch({ type: 'surface:exit' })}
-        >
-          ← Stage
-        </button>
+        <button className="back-btn" onClick={() => dispatch({ type: 'surface:exit' })}>← Stage</button>
         <span className="surface-mode-name">{surface.name}</span>
       </div>
       <div ref={areaRef} className="surface-mode-canvas-area">
         {canvasW > 0 && (
           <div
+            ref={canvasRef}
             className="surface-mode-canvas"
-            style={{ width: canvasW, height: canvasH, background: fillColor }}
-          />
+            style={{ width: canvasW, height: canvasH }}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerDown={e => { if (e.target === canvasRef.current) dispatch({ type: 'layer:select', layerId: null }) }}
+          >
+            {[...surface.layers].reverse().filter(l => l.visible).map(layer => (
+              <LayerObject
+                key={layer.id}
+                layer={layer}
+                canvasW={canvasW}
+                canvasH={canvasH}
+                isSelected={layer.id === selectedLayerId}
+                onMoveStart={e => startDrag(e, layer.id, { kind: 'move', startPx: toPx(e), startT: { ...layer.transform } })}
+                onResizeStart={(e, corner) => startDrag(e, layer.id, { kind: 'resize', corner, startPx: toPx(e), startT: { ...layer.transform } })}
+                onRotateStart={e => {
+                  const t = layer.transform
+                  const centerPx = { x: t.x * canvasW, y: t.y * canvasH }
+                  const px = toPx(e)
+                  startDrag(e, layer.id, {
+                    kind: 'rotate',
+                    centerPx,
+                    startAngle: Math.atan2(px.y - centerPx.y, px.x - centerPx.x) * 180 / Math.PI,
+                    startRotation: t.rotation,
+                  })
+                }}
+                onSelect={() => dispatch({ type: 'layer:select', layerId: layer.id })}
+              />
+            ))}
+          </div>
         )}
       </div>
+    </div>
+  )
+}
+
+// ── LayerObject ───────────────────────────────────────────────────────────────
+
+const CORNERS: Corner[] = ['tl', 'tr', 'br', 'bl']
+
+interface LayerObjectProps {
+  layer: Layer
+  canvasW: number
+  canvasH: number
+  isSelected: boolean
+  onMoveStart: (e: React.PointerEvent) => void
+  onResizeStart: (e: React.PointerEvent, corner: Corner) => void
+  onRotateStart: (e: React.PointerEvent) => void
+  onSelect: () => void
+}
+
+function LayerObject({ layer, canvasW, canvasH, isSelected, onMoveStart, onResizeStart, onRotateStart, onSelect }: LayerObjectProps) {
+  const t = layer.transform
+  const color = layer.type === 'solid' ? (layer as SolidLayer).color : 'transparent'
+
+  return (
+    <div
+      className={`layer-object${isSelected ? ' layer-object--selected' : ''}`}
+      style={{
+        left: t.x * canvasW,
+        top: t.y * canvasH,
+        width: t.w * canvasW,
+        height: t.h * canvasH,
+        transform: `translate(-50%, -50%) rotate(${t.rotation}deg)`,
+        background: color,
+      }}
+      onPointerDown={e => { e.stopPropagation(); onSelect(); onMoveStart(e) }}
+    >
+      {isSelected && (
+        <>
+          {CORNERS.map(corner => (
+            <div
+              key={corner}
+              className={`layer-handle layer-handle--resize-${corner}`}
+              onPointerDown={e => { e.stopPropagation(); onResizeStart(e, corner) }}
+            />
+          ))}
+          <div className="layer-rotate-line" />
+          <div
+            className="layer-handle layer-handle--rotate"
+            onPointerDown={e => { e.stopPropagation(); onRotateStart(e) }}
+          />
+        </>
+      )}
     </div>
   )
 }

--- a/packages/ts/lights/src/SurfaceCanvas.tsx
+++ b/packages/ts/lights/src/SurfaceCanvas.tsx
@@ -52,7 +52,7 @@ export default function SurfaceCanvas() {
 
   if (!surface || !selectedSlideId) return null
 
-  const solidLayer = surface.layers.find(l => l.type === 'solid')
+  const solidLayer = surface.layers.find(l => l.type === 'solid' && l.visible)
   const fillColor = solidLayer?.type === 'solid' ? solidLayer.color : '#111122'
   const ar = surfaceAspectRatio(surface.outputPolygon)
 

--- a/packages/ts/lights/src/SurfacePanel.tsx
+++ b/packages/ts/lights/src/SurfacePanel.tsx
@@ -1,44 +1,70 @@
+import { useState } from 'react'
 import { useProject } from './model/ProjectContext'
 import type { SolidLayer } from './model/types'
 
 export default function SurfacePanel() {
   const { state, dispatch } = useProject()
-  const { project, selectedSlideId, selectedSurfaceId, surfaceMode } = state
+  const { project, selectedSlideId, selectedSurfaceId, selectedLayerId, surfaceMode } = state
 
   const slide = project.slides.find(s => s.id === selectedSlideId)
   const surfaces = slide?.surfaces ?? []
   const surface = surfaces.find(s => s.id === selectedSurfaceId)
 
-  // ── Surface mode: show editor for the selected surface ──────────────────────
+  // ── Surface mode: layer panel ───────────────────────────────────────────────
   if (surfaceMode && surface && selectedSlideId) {
-    const solidLayer = surface.layers.find((l): l is SolidLayer => l.type === 'solid')
+    const selectedLayer = surface.layers.find(l => l.id === selectedLayerId)
+    const solidLayer = selectedLayer?.type === 'solid' ? (selectedLayer as SolidLayer) : undefined
+
+    function addLayer() {
+      dispatch({ type: 'layer:add', slideId: selectedSlideId!, surfaceId: surface!.id })
+    }
+
+    function removeLayer(layerId: string) {
+      dispatch({ type: 'layer:remove', slideId: selectedSlideId!, surfaceId: surface!.id, layerId })
+    }
+
+    function toggleVisibility(layerId: string) {
+      dispatch({ type: 'layer:toggle-visibility', slideId: selectedSlideId!, surfaceId: surface!.id, layerId })
+    }
 
     function setColor(color: string) {
-      const layers = solidLayer
-        ? surface!.layers.map(l => l.id === solidLayer!.id ? { ...solidLayer!, color } : l)
-        : [{ id: crypto.randomUUID(), type: 'solid' as const, color }, ...surface!.layers]
-      dispatch({ type: 'surface:update', slideId: selectedSlideId!, surface: { ...surface!, layers } })
+      if (!solidLayer) return
+      dispatch({ type: 'layer:update', slideId: selectedSlideId!, surfaceId: surface!.id, layer: { ...solidLayer, color } })
     }
 
     return (
       <aside className="surface-panel">
         <div className="surface-panel-header">
-          <span>{surface.name}</span>
+          <button className="back-btn" onClick={() => dispatch({ type: 'surface:exit' })}>← Stage</button>
+          <span className="surface-mode-name">{surface.name}</span>
         </div>
-        <div className="surface-editor">
-          <label className="surface-editor-label">Fill</label>
-          <input
-            type="color"
-            className="surface-editor-color"
-            value={solidLayer?.color ?? '#111122'}
-            onChange={e => setColor(e.target.value)}
-          />
-        </div>
+
+        <LayerList
+          surface={surface}
+          selectedLayerId={selectedLayerId}
+          onSelect={id => dispatch({ type: 'layer:select', layerId: id })}
+          onToggleVisibility={toggleVisibility}
+          onRemove={removeLayer}
+          onReorder={ids => dispatch({ type: 'layer:reorder', slideId: selectedSlideId!, surfaceId: surface!.id, layerIds: ids })}
+          onAdd={addLayer}
+        />
+
+        {solidLayer && (
+          <div className="surface-editor">
+            <label className="surface-editor-label">Fill</label>
+            <input
+              type="color"
+              className="surface-editor-color"
+              value={solidLayer.color}
+              onChange={e => setColor(e.target.value)}
+            />
+          </div>
+        )}
       </aside>
     )
   }
 
-  // ── Stage mode: show surface list ───────────────────────────────────────────
+  // ── Stage mode: surface list ────────────────────────────────────────────────
   return (
     <aside className="surface-panel">
       <div className="surface-panel-header">
@@ -72,7 +98,7 @@ export default function SurfacePanel() {
                 title="Remove surface"
                 onClick={e => {
                   e.stopPropagation()
-                  dispatch({ type: 'surface:remove', slideId: selectedSlideId, surfaceId: s.id })
+                  dispatch({ type: 'surface:remove', slideId: selectedSlideId!, surfaceId: s.id })
                 }}
               >
                 ×
@@ -82,5 +108,100 @@ export default function SurfacePanel() {
         </div>
       )}
     </aside>
+  )
+}
+
+// ── LayerList ─────────────────────────────────────────────────────────────────
+
+interface LayerListProps {
+  surface: { layers: import('./model/types').Layer[] }
+  selectedLayerId: string | null
+  onSelect: (id: string) => void
+  onToggleVisibility: (id: string) => void
+  onRemove: (id: string) => void
+  onReorder: (ids: string[]) => void
+  onAdd: () => void
+}
+
+function LayerList({ surface, selectedLayerId, onSelect, onToggleVisibility, onRemove, onReorder, onAdd }: LayerListProps) {
+  const [dragIdx, setDragIdx] = useState<number | null>(null)
+  const [dropIdx, setDropIdx] = useState<number | null>(null)
+
+  function handleDragStart(idx: number) {
+    setDragIdx(idx)
+  }
+
+  function handleDragOver(e: React.DragEvent, idx: number) {
+    e.preventDefault()
+    setDropIdx(idx)
+  }
+
+  function handleDrop(targetIdx: number) {
+    if (dragIdx !== null && dragIdx !== targetIdx) {
+      const reordered = [...surface.layers]
+      const [moved] = reordered.splice(dragIdx, 1)
+      reordered.splice(targetIdx, 0, moved)
+      onReorder(reordered.map(l => l.id))
+    }
+    setDragIdx(null)
+    setDropIdx(null)
+  }
+
+  function handleDragEnd() {
+    setDragIdx(null)
+    setDropIdx(null)
+  }
+
+  return (
+    <div className="layer-panel">
+      <div className="layer-panel-header">
+        <span>Layers</span>
+        <button className="icon-btn" title="Add layer" onClick={onAdd}>+</button>
+      </div>
+
+      {surface.layers.length === 0 ? (
+        <p className="panel-empty">No layers</p>
+      ) : (
+        <div className="layer-list">
+          {surface.layers.map((layer, idx) => (
+            <div
+              key={layer.id}
+              className={[
+                'layer-item',
+                layer.id === selectedLayerId ? 'selected' : '',
+                dragIdx === idx ? 'dragging' : '',
+                dropIdx === idx && dragIdx !== idx ? 'drop-target' : '',
+              ].filter(Boolean).join(' ')}
+              draggable
+              onDragStart={() => handleDragStart(idx)}
+              onDragOver={e => handleDragOver(e, idx)}
+              onDrop={() => handleDrop(idx)}
+              onDragEnd={handleDragEnd}
+              onClick={() => onSelect(layer.id)}
+            >
+              <span className="layer-drag-handle">⠿</span>
+              <button
+                className="icon-btn layer-visibility"
+                title={layer.visible ? 'Hide' : 'Show'}
+                onClick={e => { e.stopPropagation(); onToggleVisibility(layer.id) }}
+              >
+                {layer.visible ? '●' : '○'}
+              </button>
+              <span className="layer-name">{layer.name}</span>
+              {layer.type === 'solid' && (
+                <span className="layer-color-swatch" style={{ background: (layer as SolidLayer).color }} />
+              )}
+              <button
+                className="icon-btn layer-remove"
+                title="Remove layer"
+                onClick={e => { e.stopPropagation(); onRemove(layer.id) }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }

--- a/packages/ts/lights/src/SurfacePanel.tsx
+++ b/packages/ts/lights/src/SurfacePanel.tsx
@@ -35,8 +35,7 @@ export default function SurfacePanel() {
     return (
       <aside className="surface-panel">
         <div className="surface-panel-header">
-          <button className="back-btn" onClick={() => dispatch({ type: 'surface:exit' })}>← Stage</button>
-          <span className="surface-mode-name">{surface.name}</span>
+          <span>{surface.name}</span>
         </div>
 
         <LayerList

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -269,6 +269,112 @@ html, body, #root {
   flex-shrink: 0;
 }
 
+/* ── Layer panel ─────────────────────────────────────────────────────────── */
+
+.layer-panel {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid #1a1a1a;
+}
+
+.layer-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px 6px;
+  font-size: 10px;
+  color: #444;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.layer-list {
+  overflow-y: auto;
+  padding: 4px 8px;
+  max-height: 200px;
+}
+
+.layer-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #666;
+  user-select: none;
+}
+
+.layer-item:hover {
+  background: #1a1a1a;
+  color: #ccc;
+}
+
+.layer-item.selected {
+  background: #1a2744;
+  color: #60a5fa;
+}
+
+.layer-item.dragging {
+  opacity: 0.4;
+}
+
+.layer-item.drop-target {
+  border-top: 2px solid #60a5fa;
+}
+
+.layer-drag-handle {
+  color: #333;
+  cursor: grab;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.layer-item:hover .layer-drag-handle {
+  color: #555;
+}
+
+.layer-visibility {
+  color: #444;
+  flex-shrink: 0;
+}
+
+.layer-item.selected .layer-visibility {
+  color: #5090d0;
+}
+
+.layer-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.layer-color-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  border: 1px solid #333;
+  flex-shrink: 0;
+}
+
+.layer-remove {
+  opacity: 0;
+  color: #555;
+  flex-shrink: 0;
+}
+
+.layer-item:hover .layer-remove,
+.layer-item.selected .layer-remove {
+  opacity: 1;
+}
+
+.layer-remove:hover {
+  color: #ef4444 !important;
+}
+
 /* ── Surface editor (right panel in surface mode) ────────────────────────── */
 
 .surface-editor {

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -267,6 +267,53 @@ html, body, #root {
 
 .surface-mode-canvas {
   flex-shrink: 0;
+  position: relative;
+  background: #111;
+  user-select: none;
+}
+
+/* ── Layer objects & handles ─────────────────────────────────────────────── */
+
+.layer-object {
+  position: absolute;
+  box-sizing: border-box;
+  cursor: move;
+}
+
+.layer-object--selected {
+  outline: 1px solid rgba(96, 165, 250, 0.6);
+}
+
+.layer-handle {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: #1a3060;
+  border: 1.5px solid #60a5fa;
+  border-radius: 1px;
+  z-index: 1;
+}
+
+.layer-handle--resize-tl { top: -4px;    left: -4px;              cursor: nwse-resize; }
+.layer-handle--resize-tr { top: -4px;    right: -4px;             cursor: nesw-resize; }
+.layer-handle--resize-br { bottom: -4px; right: -4px;             cursor: nwse-resize; }
+.layer-handle--resize-bl { bottom: -4px; left: -4px;              cursor: nesw-resize; }
+
+.layer-handle--rotate {
+  top: -28px;
+  left: calc(50% - 4px);
+  border-radius: 50%;
+  cursor: crosshair;
+}
+
+.layer-rotate-line {
+  position: absolute;
+  top: -20px;
+  left: calc(50% - 0.5px);
+  width: 1px;
+  height: 20px;
+  background: rgba(96, 165, 250, 0.4);
+  pointer-events: none;
 }
 
 /* ── Layer panel ─────────────────────────────────────────────────────────── */

--- a/packages/ts/lights/src/homography.ts
+++ b/packages/ts/lights/src/homography.ts
@@ -25,18 +25,14 @@ void main() {
 }
 `
 
-const fragmentShaderSolid = /* glsl */`
+// Flip V to compensate for Three.js's default flipY on canvas textures
+const fragmentShaderTexture = /* glsl */`
 varying vec2 vUv;
-uniform vec3 uColor;
+uniform sampler2D uTexture;
 void main() {
-  gl_FragColor = vec4(uColor, 1.0);
+  gl_FragColor = texture2D(uTexture, vec2(vUv.x, 1.0 - vUv.y));
 }
 `
-
-function hexToVec3(hex: string): THREE.Vector3 {
-  const n = parseInt(hex.replace('#', ''), 16)
-  return new THREE.Vector3(((n >> 16) & 255) / 255, ((n >> 8) & 255) / 255, (n & 255) / 255)
-}
 
 // ── Math ─────────────────────────────────────────────────────────────────────
 
@@ -76,6 +72,38 @@ function computeHomography(src: [number, number][], dst: [number, number][]): nu
     b.push(y)
   }
   return [...gaussianElim(A, b), 1]
+}
+
+// ── Texture compositor ────────────────────────────────────────────────────────
+
+// Composite all visible layers onto an offscreen canvas (surface local space,
+// Y-down), then wrap it in a Three.js CanvasTexture. Returns null if no layers.
+const TEX_SIZE = 512
+
+function buildSurfaceTexture(surface: Surface): THREE.CanvasTexture | null {
+  const visibleLayers = surface.layers.filter(l => l.visible)
+  if (visibleLayers.length === 0) return null
+
+  const canvas = document.createElement('canvas')
+  canvas.width  = TEX_SIZE
+  canvas.height = TEX_SIZE
+  const ctx = canvas.getContext('2d')!
+
+  // Render bottom-to-top: surface.layers[0] is the top layer in the panel,
+  // so we iterate in reverse to draw the backmost layer first.
+  for (const layer of [...surface.layers].reverse()) {
+    if (!layer.visible || layer.type !== 'solid') continue
+    const l = layer as SolidLayer
+    const t = l.transform
+    ctx.save()
+    ctx.translate(t.x * TEX_SIZE, t.y * TEX_SIZE)
+    ctx.rotate(t.rotation * Math.PI / 180)
+    ctx.fillStyle = l.color
+    ctx.fillRect(-t.w * TEX_SIZE / 2, -t.h * TEX_SIZE / 2, t.w * TEX_SIZE, t.h * TEX_SIZE)
+    ctx.restore()
+  }
+
+  return new THREE.CanvasTexture(canvas)
 }
 
 // ── Mesh builder ─────────────────────────────────────────────────────────────
@@ -120,13 +148,13 @@ export function buildSurfaceMesh(surface: Surface, colorIdx: number): THREE.Mesh
   geo.setAttribute('aW',       new THREE.BufferAttribute(ws, 1))
   geo.setIndex([0, 1, 2, 0, 2, 3])
 
-  const solidLayer = surface.layers.find((l): l is SolidLayer => l.type === 'solid' && l.visible)
-  const material = solidLayer
+  const texture = buildSurfaceTexture(surface)
+  const material = texture
     ? new THREE.ShaderMaterial({
         vertexShader,
-        fragmentShader: fragmentShaderSolid,
-        uniforms: { uColor: { value: hexToVec3(solidLayer.color) } },
-        transparent: false,
+        fragmentShader: fragmentShaderTexture,
+        uniforms: { uTexture: { value: texture } },
+        transparent: true,
         side: THREE.DoubleSide,
         depthTest: false,
       })
@@ -144,5 +172,7 @@ export function buildSurfaceMesh(surface: Surface, colorIdx: number): THREE.Mesh
 
 export function disposeSurfaceMesh(mesh: THREE.Mesh): void {
   mesh.geometry.dispose()
-  ;(mesh.material as THREE.Material).dispose()
+  const mat = mesh.material as THREE.ShaderMaterial
+  ;(mat.uniforms.uTexture?.value as THREE.Texture | undefined)?.dispose()
+  mat.dispose()
 }

--- a/packages/ts/lights/src/homography.ts
+++ b/packages/ts/lights/src/homography.ts
@@ -120,7 +120,7 @@ export function buildSurfaceMesh(surface: Surface, colorIdx: number): THREE.Mesh
   geo.setAttribute('aW',       new THREE.BufferAttribute(ws, 1))
   geo.setIndex([0, 1, 2, 0, 2, 3])
 
-  const solidLayer = surface.layers.find((l): l is SolidLayer => l.type === 'solid')
+  const solidLayer = surface.layers.find((l): l is SolidLayer => l.type === 'solid' && l.visible)
   const material = solidLayer
     ? new THREE.ShaderMaterial({
         vertexShader,

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -172,7 +172,8 @@ function reducer(state: ProjectState, action: ProjectAction): ProjectState {
         type: 'solid',
         name: `Layer ${surface.layers.length + 1}`,
         visible: true,
-        color: '#111122',
+        color: '#3a6ea5',
+        transform: { x: 0.5, y: 0.5, w: 0.8, h: 0.8, rotation: 0 },
       }
       return {
         ...patchSurfaceLayers(state, action.slideId, action.surfaceId, layers => [layer, ...layers]),

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useReducer } from 'react'
 import type { Dispatch, ReactNode } from 'react'
-import type { Project, Slide, Surface } from './types'
+import type { Layer, Project, Slide, Surface } from './types'
 
 // ── State ────────────────────────────────────────────────────────────────────
 
@@ -8,6 +8,7 @@ export interface ProjectState {
   project: Project
   selectedSlideId: string | null
   selectedSurfaceId: string | null
+  selectedLayerId: string | null
   surfaceMode: boolean  // true = flat local editor open
 }
 
@@ -15,6 +16,7 @@ const initial: ProjectState = {
   project: { slides: [], calibration: {} },
   selectedSlideId: null,
   selectedSurfaceId: null,
+  selectedLayerId: null,
   surfaceMode: false,
 }
 
@@ -30,8 +32,33 @@ export type ProjectAction =
   | { type: 'surface:select'; surfaceId: string | null }
   | { type: 'surface:enter' }   // double-click → open flat editor
   | { type: 'surface:exit' }    // back / Escape → return to stage, keep selection
+  | { type: 'layer:add'; slideId: string; surfaceId: string }
+  | { type: 'layer:remove'; slideId: string; surfaceId: string; layerId: string }
+  | { type: 'layer:update'; slideId: string; surfaceId: string; layer: Layer }
+  | { type: 'layer:reorder'; slideId: string; surfaceId: string; layerIds: string[] }
+  | { type: 'layer:select'; layerId: string | null }
+  | { type: 'layer:toggle-visibility'; slideId: string; surfaceId: string; layerId: string }
 
 // ── Reducer ──────────────────────────────────────────────────────────────────
+
+function patchSurfaceLayers(
+  state: ProjectState,
+  slideId: string,
+  surfaceId: string,
+  fn: (layers: Layer[]) => Layer[]
+): ProjectState {
+  return {
+    ...state,
+    project: {
+      ...state.project,
+      slides: state.project.slides.map(s =>
+        s.id === slideId
+          ? { ...s, surfaces: s.surfaces.map(sf => sf.id === surfaceId ? { ...sf, layers: fn(sf.layers) } : sf) }
+          : s
+      ),
+    },
+  }
+}
 
 function reducer(state: ProjectState, action: ProjectAction): ProjectState {
   const { project } = state
@@ -69,7 +96,7 @@ function reducer(state: ProjectState, action: ProjectAction): ProjectState {
     }
 
     case 'slide:select':
-      return { ...state, selectedSlideId: action.slideId, selectedSurfaceId: null, surfaceMode: false }
+      return { ...state, selectedSlideId: action.slideId, selectedSurfaceId: null, selectedLayerId: null, surfaceMode: false }
 
     case 'surface:add': {
       const surface: Surface = {
@@ -127,14 +154,60 @@ function reducer(state: ProjectState, action: ProjectAction): ProjectState {
     }
 
     case 'surface:select':
-      return { ...state, selectedSurfaceId: action.surfaceId, surfaceMode: false }
+      return { ...state, selectedSurfaceId: action.surfaceId, selectedLayerId: null, surfaceMode: false }
 
     case 'surface:enter':
       if (!state.selectedSurfaceId) return state
       return { ...state, surfaceMode: true }
 
     case 'surface:exit':
-      return { ...state, surfaceMode: false }
+      return { ...state, surfaceMode: false, selectedLayerId: null }
+
+    case 'layer:add': {
+      const slide = project.slides.find(s => s.id === action.slideId)
+      const surface = slide?.surfaces.find(sf => sf.id === action.surfaceId)
+      if (!surface) return state
+      const layer: Layer = {
+        id: crypto.randomUUID(),
+        type: 'solid',
+        name: `Layer ${surface.layers.length + 1}`,
+        visible: true,
+        color: '#111122',
+      }
+      return {
+        ...patchSurfaceLayers(state, action.slideId, action.surfaceId, layers => [layer, ...layers]),
+        selectedLayerId: layer.id,
+      }
+    }
+
+    case 'layer:remove': {
+      const next = patchSurfaceLayers(state, action.slideId, action.surfaceId, layers =>
+        layers.filter(l => l.id !== action.layerId)
+      )
+      return {
+        ...next,
+        selectedLayerId: state.selectedLayerId === action.layerId ? null : state.selectedLayerId,
+      }
+    }
+
+    case 'layer:update':
+      return patchSurfaceLayers(state, action.slideId, action.surfaceId, layers =>
+        layers.map(l => l.id === action.layer.id ? action.layer : l)
+      )
+
+    case 'layer:reorder':
+      return patchSurfaceLayers(state, action.slideId, action.surfaceId, layers => {
+        const map = new Map(layers.map(l => [l.id, l]))
+        return action.layerIds.flatMap(id => (map.has(id) ? [map.get(id)!] : []))
+      })
+
+    case 'layer:select':
+      return { ...state, selectedLayerId: action.layerId }
+
+    case 'layer:toggle-visibility':
+      return patchSurfaceLayers(state, action.slideId, action.surfaceId, layers =>
+        layers.map(l => l.id === action.layerId ? { ...l, visible: !l.visible } : l)
+      )
   }
 }
 

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -4,7 +4,7 @@ export type { Point, GraphConfig }
 
 export type Polygon = Point[]
 
-export interface SolidLayer { id: string; type: 'solid'; color: string }
+export interface SolidLayer { id: string; type: 'solid'; name: string; visible: boolean; color: string }
 export type Layer = SolidLayer  // union grows in M3
 
 export interface Reaction { id: string }

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -4,7 +4,15 @@ export type { Point, GraphConfig }
 
 export type Polygon = Point[]
 
-export interface SolidLayer { id: string; type: 'solid'; name: string; visible: boolean; color: string }
+export interface LayerTransform {
+  x: number        // center, normalized [0,1]
+  y: number        // center, normalized [0,1]
+  w: number        // width fraction [0,1]
+  h: number        // height fraction [0,1]
+  rotation: number // degrees
+}
+
+export interface SolidLayer { id: string; type: 'solid'; name: string; visible: boolean; color: string; transform: LayerTransform }
 export type Layer = SolidLayer  // union grows in M3
 
 export interface Reaction { id: string }


### PR DESCRIPTION
## Summary
- Adds `LayerTransform` (`x`, `y`, `w`, `h`, `rotation`) to the `Layer` type; default transform centers new layers at 80% size
- Interactive surface canvas: drag body to move, 4 corner handles to resize (hold Shift to aspect-lock), rotation handle above top-center rotates around the layer's center
- Pointer capture on the canvas element ensures drag stays live when the pointer leaves the canvas
- Fixed spurious deselect when reaching for handles: canvas uses `onPointerDown` (not `onClick`) for deselect, and layer `onPointerDown` stops propagation
- Replaced the single solid-color shader with an **offscreen canvas compositor**: all visible layers are rendered bottom-to-top with their 2D transforms onto a 512×512 `CanvasTexture`, then one homography mesh is applied — stage preview and output window now show the full multi-layer composition at the correct positions

## Test plan
- [ ] Add a layer and drag it to reposition
- [ ] Drag a corner handle to resize; hold Shift for aspect lock
- [ ] Drag the rotation handle to rotate around the layer center
- [ ] Click the canvas background to deselect; verify handles disappear
- [ ] Add a second layer with a different color and position — verify both appear in stage mode and output window at their correct positions
- [ ] Toggle layer visibility — verify it disappears from stage/output
- [ ] Reorder layers in the panel — verify z-order updates in stage/output

🤖 Generated with [Claude Code](https://claude.com/claude-code)