### PR TITLE
feat(project): save and load project via native file dialogs

### DIFF
--- a/packages/ts/lights/electron/main.ts
+++ b/packages/ts/lights/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, Menu } from 'electron'
 import { fileURLToPath } from 'node:url'
 import fs from 'node:fs/promises'
 import path from 'node:path'
@@ -15,6 +15,8 @@ let win: BrowserWindow | null = null
 let outputWin: BrowserWindow | null = null
 let lastSlide: unknown = null
 let stubInterval: ReturnType<typeof setInterval> | null = null
+let currentFilePath: string | null = null
+let isDirty = false
 
 function emit(event: GraphEvent) {
   win?.webContents.send('graph:event', event)
@@ -85,6 +87,117 @@ ipcMain.handle('dialog:pick-image', async () => {
   return { name: path.basename(filePath), src: `data:${mime};base64,${data.toString('base64')}` }
 })
 
+function winTitle() {
+  const base = currentFilePath ? path.basename(currentFilePath) : 'Untitled'
+  return isDirty ? `Lights — ${base} •` : `Lights — ${base}`
+}
+
+ipcMain.handle('project:save', async (_event, { project }: { project: unknown }) => {
+  let filePath = currentFilePath
+  if (!filePath) {
+    const result = await dialog.showSaveDialog(win!, {
+      defaultPath: 'project.lights.json',
+      filters: [{ name: 'Lights Project', extensions: ['json'] }],
+    })
+    if (result.canceled || !result.filePath) return null
+    filePath = result.filePath
+  }
+  await fs.writeFile(filePath, JSON.stringify(project, null, 2), 'utf-8')
+  currentFilePath = filePath
+  isDirty = false
+  win?.setTitle(winTitle())
+  return { filePath }
+})
+
+ipcMain.handle('project:save-as', async (_event, { project }: { project: unknown }) => {
+  const result = await dialog.showSaveDialog(win!, {
+    defaultPath: currentFilePath ? path.basename(currentFilePath) : 'project.lights.json',
+    filters: [{ name: 'Lights Project', extensions: ['json'] }],
+  })
+  if (result.canceled || !result.filePath) return null
+  const filePath = result.filePath
+  await fs.writeFile(filePath, JSON.stringify(project, null, 2), 'utf-8')
+  currentFilePath = filePath
+  isDirty = false
+  win?.setTitle(winTitle())
+  return { filePath }
+})
+
+ipcMain.on('project:set-dirty', (_event, dirty: boolean) => {
+  isDirty = dirty
+  win?.setTitle(winTitle())
+})
+
+ipcMain.on('project:quit-confirmed', () => {
+  isDirty = false
+  win?.destroy()
+})
+
+function buildMenu() {
+  const template: Electron.MenuItemConstructorOptions[] = [
+    { role: 'appMenu' },
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'New',
+          accelerator: 'CmdOrCtrl+N',
+          click: () => {
+            currentFilePath = null
+            isDirty = false
+            win?.setTitle('Lights')
+            win?.webContents.send('menu:new')
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'Open…',
+          accelerator: 'CmdOrCtrl+O',
+          click: async () => {
+            const result = await dialog.showOpenDialog(win!, {
+              filters: [{ name: 'Lights Project', extensions: ['json'] }],
+              properties: ['openFile'],
+            })
+            if (result.canceled || result.filePaths.length === 0) return
+            const filePath = result.filePaths[0]
+            try {
+              const data = await fs.readFile(filePath, 'utf-8')
+              const project = JSON.parse(data)
+              currentFilePath = filePath
+              isDirty = false
+              win?.setTitle(winTitle())
+              win?.webContents.send('project:opened', { project, filePath })
+            } catch {
+              await dialog.showMessageBox(win!, {
+                type: 'error',
+                message: 'Could not open project',
+                detail: `Failed to read ${path.basename(filePath)}.`,
+              })
+            }
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'Save',
+          accelerator: 'CmdOrCtrl+S',
+          click: () => win?.webContents.send('menu:save'),
+        },
+        {
+          label: 'Save As…',
+          accelerator: 'CmdOrCtrl+Shift+S',
+          click: () => win?.webContents.send('menu:save-as'),
+        },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    },
+    { role: 'editMenu' },
+    { role: 'viewMenu' },
+    { role: 'windowMenu' },
+  ]
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+}
+
 ipcMain.on('output:slide', (_event, slide: unknown) => {
   lastSlide = slide
   outputWin?.webContents.send('output:render', slide)
@@ -139,6 +252,26 @@ function createWindow() {
     },
   })
 
+  win.on('close', (e) => {
+    if (!isDirty) return
+    e.preventDefault()
+    dialog.showMessageBox(win!, {
+      type: 'question',
+      buttons: ['Save', "Don't Save", 'Cancel'],
+      defaultId: 0,
+      cancelId: 2,
+      message: 'Save changes to your project?',
+      detail: 'Your changes will be lost if you don\'t save them.',
+    }).then(({ response }) => {
+      if (response === 0) {
+        win?.webContents.send('menu:save-and-quit')
+      } else if (response === 1) {
+        isDirty = false
+        win?.destroy()
+      }
+    })
+  })
+
   win.on('closed', () => {
     win = null
     stopStubGraph()
@@ -153,6 +286,7 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  buildMenu()
   createWindow()
   createOutputWindow()
 })

--- a/packages/ts/lights/electron/preload.ts
+++ b/packages/ts/lights/electron/preload.ts
@@ -1,6 +1,12 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { GraphCommand, GraphEvent, LightsBridge } from '../src/ipc/types'
 
+function onChannel(channel: string, handler: (...args: unknown[]) => void): () => void {
+  const listener = (_: Electron.IpcRendererEvent, ...args: unknown[]) => handler(...args)
+  ipcRenderer.on(channel, listener)
+  return () => ipcRenderer.off(channel, listener)
+}
+
 const bridge: LightsBridge = {
   sendCommand: (cmd: GraphCommand) => ipcRenderer.send('graph:command', cmd),
   onEvent: (handler: (event: GraphEvent) => void) => {
@@ -15,6 +21,20 @@ const bridge: LightsBridge = {
     return () => ipcRenderer.off('output:render', listener)
   },
   pickImageFile: () => ipcRenderer.invoke('dialog:pick-image') as Promise<{ name: string; src: string } | null>,
+
+  saveProject: (project: unknown) =>
+    ipcRenderer.invoke('project:save', { project }) as Promise<{ filePath: string } | null>,
+  saveProjectAs: (project: unknown) =>
+    ipcRenderer.invoke('project:save-as', { project }) as Promise<{ filePath: string } | null>,
+  notifyDirty: (isDirty: boolean) => ipcRenderer.send('project:set-dirty', isDirty),
+  confirmQuit: () => ipcRenderer.send('project:quit-confirmed'),
+
+  onMenuSave: (handler) => onChannel('menu:save', handler),
+  onMenuSaveAs: (handler) => onChannel('menu:save-as', handler),
+  onMenuSaveAndQuit: (handler) => onChannel('menu:save-and-quit', handler),
+  onMenuNew: (handler) => onChannel('menu:new', handler),
+  onProjectOpened: (handler) =>
+    onChannel('project:opened', (data) => handler(data as { project: unknown; filePath: string })),
 }
 
 contextBridge.exposeInMainWorld('lights', bridge)

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -78,6 +78,22 @@ html, body, #root {
   white-space: nowrap;
 }
 
+.slide-item.selected .slide-name {
+  cursor: text;
+}
+
+.rename-input {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  border-bottom: 1px solid #60a5fa;
+  color: inherit;
+  font: inherit;
+  outline: none;
+  padding: 0;
+}
+
 .slide-action {
   opacity: 0;
   margin-left: 4px;
@@ -199,6 +215,14 @@ html, body, #root {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.surface-item.selected .surface-name {
+  cursor: text;
+}
+
+.surface-panel-title {
+  cursor: text;
 }
 
 .surface-remove {

--- a/packages/ts/lights/src/components/SlidePanel.tsx
+++ b/packages/ts/lights/src/components/SlidePanel.tsx
@@ -1,12 +1,23 @@
+import { useState } from 'react'
 import { useProject } from '../model/ProjectContext'
 
-/**
- * Left sidebar panel displaying the slide list.
- * Supports adding, removing, and selecting slides.
- */
 export default function SlidePanel() {
   const { state, dispatch } = useProject()
   const { project, selectedSlideId } = state
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+
+  function startEdit(slideId: string, name: string, e: React.MouseEvent) {
+    e.stopPropagation()
+    setEditingId(slideId)
+    setEditValue(name)
+  }
+
+  function commit(slideId: string) {
+    const trimmed = editValue.trim()
+    if (trimmed) dispatch({ type: 'slide:rename', slideId, name: trimmed })
+    setEditingId(null)
+  }
 
   return (
     <aside className="slide-panel">
@@ -29,9 +40,34 @@ export default function SlidePanel() {
             <div
               key={slide.id}
               className={`slide-item${slide.id === selectedSlideId ? ' selected' : ''}`}
-              onClick={() => dispatch({ type: 'slide:select', slideId: slide.id })}
+              onClick={() => {
+                if (editingId !== slide.id) dispatch({ type: 'slide:select', slideId: slide.id })
+              }}
             >
-              <span className="slide-name">{slide.name}</span>
+              {editingId === slide.id ? (
+                <input
+                  autoFocus
+                  className="rename-input"
+                  value={editValue}
+                  onFocus={e => e.target.select()}
+                  onChange={e => setEditValue(e.target.value)}
+                  onBlur={() => commit(slide.id)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') e.currentTarget.blur()
+                    if (e.key === 'Escape') setEditingId(null)
+                  }}
+                  onClick={e => e.stopPropagation()}
+                />
+              ) : (
+                <span
+                  className="slide-name"
+                  onClick={e => {
+                    if (slide.id === selectedSlideId) startEdit(slide.id, slide.name, e)
+                  }}
+                >
+                  {slide.name}
+                </span>
+              )}
               <button
                 className="icon-btn slide-action"
                 title="Duplicate slide"

--- a/packages/ts/lights/src/components/SurfacePanel.tsx
+++ b/packages/ts/lights/src/components/SurfacePanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useProject } from '../model/ProjectContext'
 import type { SolidLayer, TextLayer } from '../model/types'
 import LayerList from './LayerList'
@@ -12,6 +13,20 @@ import LayerList from './LayerList'
 export default function SurfacePanel() {
   const { state, dispatch } = useProject()
   const { project, selectedSlideId, selectedSurfaceId, selectedLayerId, surfaceMode } = state
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+
+  function startEdit(surfaceId: string, name: string, e: React.MouseEvent) {
+    e.stopPropagation()
+    setEditingId(surfaceId)
+    setEditValue(name)
+  }
+
+  function commit(surfaceId: string) {
+    const trimmed = editValue.trim()
+    if (trimmed && selectedSlideId) dispatch({ type: 'surface:rename', slideId: selectedSlideId, surfaceId, name: trimmed })
+    setEditingId(null)
+  }
 
   const slide = project.slides.find(s => s.id === selectedSlideId)
   const surfaces = slide?.surfaces ?? []
@@ -34,7 +49,27 @@ export default function SurfacePanel() {
     return (
       <aside className="surface-panel">
         <div className="surface-panel-header">
-          <span>{surface.name}</span>
+          {editingId === surface.id ? (
+            <input
+              autoFocus
+              className="rename-input"
+              value={editValue}
+              onFocus={e => e.target.select()}
+              onChange={e => setEditValue(e.target.value)}
+              onBlur={() => commit(surface.id)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') e.currentTarget.blur()
+                if (e.key === 'Escape') setEditingId(null)
+              }}
+            />
+          ) : (
+            <span
+              className="surface-panel-title"
+              onClick={e => startEdit(surface.id, surface.name, e)}
+            >
+              {surface.name}
+            </span>
+          )}
         </div>
 
         <LayerList
@@ -114,9 +149,34 @@ export default function SurfacePanel() {
             <div
               key={s.id}
               className={`surface-item${s.id === selectedSurfaceId ? ' selected' : ''}`}
-              onClick={() => dispatch({ type: 'surface:select', surfaceId: s.id })}
+              onClick={() => {
+                if (editingId !== s.id) dispatch({ type: 'surface:select', surfaceId: s.id })
+              }}
             >
-              <span className="surface-name">{s.name}</span>
+              {editingId === s.id ? (
+                <input
+                  autoFocus
+                  className="rename-input"
+                  value={editValue}
+                  onFocus={e => e.target.select()}
+                  onChange={e => setEditValue(e.target.value)}
+                  onBlur={() => commit(s.id)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') e.currentTarget.blur()
+                    if (e.key === 'Escape') setEditingId(null)
+                  }}
+                  onClick={e => e.stopPropagation()}
+                />
+              ) : (
+                <span
+                  className="surface-name"
+                  onClick={e => {
+                    if (s.id === selectedSurfaceId) startEdit(s.id, s.name, e)
+                  }}
+                >
+                  {s.name}
+                </span>
+              )}
               <button
                 className="icon-btn surface-remove"
                 title="Remove surface"

--- a/packages/ts/lights/src/ipc/types.ts
+++ b/packages/ts/lights/src/ipc/types.ts
@@ -49,6 +49,23 @@ export interface LightsBridge {
   onOutputRender: (handler: (slide: unknown) => void) => () => void
   /** Open the native OS file picker filtered to image types. Returns name + base64 data URL, or null if cancelled. */
   pickImageFile: () => Promise<{ name: string; src: string } | null>
+
+  // Project persistence
+  /** Save project to the current file path (or show Save dialog if none). Returns the file path used, or null if cancelled. */
+  saveProject: (project: unknown) => Promise<{ filePath: string } | null>
+  /** Always shows a Save As dialog. Returns the file path used, or null if cancelled. */
+  saveProjectAs: (project: unknown) => Promise<{ filePath: string } | null>
+  /** Notify main of unsaved-changes state (used for close confirmation). */
+  notifyDirty: (isDirty: boolean) => void
+  /** Tell main the renderer is ready to quit (called after successful save-and-quit). */
+  confirmQuit: () => void
+
+  // Menu events (main → renderer)
+  onMenuSave: (handler: () => void) => () => void
+  onMenuSaveAs: (handler: () => void) => () => void
+  onMenuSaveAndQuit: (handler: () => void) => () => void
+  onMenuNew: (handler: () => void) => () => void
+  onProjectOpened: (handler: (data: { project: unknown; filePath: string }) => void) => () => void
 }
 
 declare global {

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -31,6 +31,8 @@ export type ProjectAction =
   | { type: 'project:saved'; filePath: string }
   | { type: 'project:new' }
   | { type: 'slide:add' }
+  | { type: 'slide:rename'; slideId: string; name: string }
+  | { type: 'surface:rename'; slideId: string; surfaceId: string; name: string }
   | { type: 'slide:duplicate'; slideId: string }
   | { type: 'slide:remove'; slideId: string }
   | { type: 'slide:select'; slideId: string | null }
@@ -316,6 +318,28 @@ function projectMutationReducer(state: ProjectState, action: ProjectAction): Pro
       return patchSurfaceLayers(state, action.slideId, action.surfaceId, layers =>
         layers.map(l => l.id === action.layerId ? { ...l, visible: !l.visible } : l)
       )
+
+    case 'slide:rename':
+      return {
+        ...state,
+        project: {
+          ...project,
+          slides: project.slides.map(s => s.id === action.slideId ? { ...s, name: action.name } : s),
+        },
+      }
+
+    case 'surface:rename':
+      return {
+        ...state,
+        project: {
+          ...project,
+          slides: project.slides.map(s =>
+            s.id === action.slideId
+              ? { ...s, surfaces: s.surfaces.map(sf => sf.id === action.surfaceId ? { ...sf, name: action.name } : sf) }
+              : s
+          ),
+        },
+      }
 
     default:
       return state

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useReducer } from 'react'
+import { createContext, useContext, useEffect, useReducer, useRef } from 'react'
 import type { Dispatch, ReactNode } from 'react'
 import type { ImageLayer, Layer, Project, Slide, Surface, TextLayer } from './types'
 
@@ -10,6 +10,8 @@ export interface ProjectState {
   selectedSurfaceId: string | null
   selectedLayerId: string | null
   surfaceMode: boolean  // true = flat local editor open
+  isDirty: boolean
+  currentFilePath: string | null
 }
 
 const initial: ProjectState = {
@@ -18,11 +20,16 @@ const initial: ProjectState = {
   selectedSurfaceId: null,
   selectedLayerId: null,
   surfaceMode: false,
+  isDirty: false,
+  currentFilePath: null,
 }
 
 // ── Actions ──────────────────────────────────────────────────────────────────
 
 export type ProjectAction =
+  | { type: 'project:load'; project: Project; filePath: string }
+  | { type: 'project:saved'; filePath: string }
+  | { type: 'project:new' }
   | { type: 'slide:add' }
   | { type: 'slide:duplicate'; slideId: string }
   | { type: 'slide:remove'; slideId: string }
@@ -65,6 +72,28 @@ function patchSurfaceLayers(
 }
 
 function reducer(state: ProjectState, action: ProjectAction): ProjectState {
+  // Project-level actions that manage dirty/path themselves
+  if (action.type === 'project:load') {
+    return {
+      ...initial,
+      project: action.project,
+      currentFilePath: action.filePath,
+      selectedSlideId: action.project.slides[0]?.id ?? null,
+    }
+  }
+  if (action.type === 'project:saved') {
+    return { ...state, isDirty: false, currentFilePath: action.filePath }
+  }
+  if (action.type === 'project:new') {
+    return { ...initial }
+  }
+
+  const next = projectMutationReducer(state, action)
+  // Auto-mark dirty whenever the project object reference changes
+  return next.project !== state.project ? { ...next, isDirty: true } : next
+}
+
+function projectMutationReducer(state: ProjectState, action: ProjectAction): ProjectState {
   const { project } = state
 
   switch (action.type) {
@@ -287,6 +316,9 @@ function reducer(state: ProjectState, action: ProjectAction): ProjectState {
       return patchSurfaceLayers(state, action.slideId, action.surfaceId, layers =>
         layers.map(l => l.id === action.layerId ? { ...l, visible: !l.visible } : l)
       )
+
+    default:
+      return state
   }
 }
 
@@ -301,6 +333,8 @@ const ProjectContext = createContext<ContextValue | null>(null)
 
 export function ProjectProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initial)
+  const stateRef = useRef(state)
+  stateRef.current = state
 
   useEffect(() => {
     if (state.selectedSlideId === null) return
@@ -313,6 +347,45 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
     window.lights.sendCommand({ type: 'slide:activate', config: slide.graphConfig, aois })
     window.lights.sendSlide(slide)
   }, [state.selectedSlideId, state.project.slides])
+
+  // Notify main of dirty state for close confirmation
+  useEffect(() => {
+    window.lights.notifyDirty(state.isDirty)
+  }, [state.isDirty])
+
+  // Wire up File menu events from the main process
+  useEffect(() => {
+    const save = async () => {
+      const result = await window.lights.saveProject(stateRef.current.project)
+      if (result) dispatch({ type: 'project:saved', filePath: result.filePath })
+    }
+
+    const offSave = window.lights.onMenuSave(save)
+
+    const offSaveAs = window.lights.onMenuSaveAs(async () => {
+      const result = await window.lights.saveProjectAs(stateRef.current.project)
+      if (result) dispatch({ type: 'project:saved', filePath: result.filePath })
+    })
+
+    const offSaveAndQuit = window.lights.onMenuSaveAndQuit(async () => {
+      const result = await window.lights.saveProject(stateRef.current.project)
+      if (result) {
+        dispatch({ type: 'project:saved', filePath: result.filePath })
+        window.lights.confirmQuit()
+      }
+    })
+
+    const offOpened = window.lights.onProjectOpened(({ project, filePath }) => {
+      dispatch({ type: 'project:load', project: project as Project, filePath })
+    })
+
+    const offNew = window.lights.onMenuNew(() => {
+      if (stateRef.current.isDirty && !window.confirm('Discard unsaved changes?')) return
+      dispatch({ type: 'project:new' })
+    })
+
+    return () => { offSave(); offSaveAs(); offSaveAndQuit(); offOpened(); offNew() }
+  }, [])
 
   return <ProjectContext.Provider value={{ state, dispatch }}>{children}</ProjectContext.Provider>
 }


### PR DESCRIPTION
Closes #32

## Summary
- **File menu** (New / Open… / Save / Save As…) with standard macOS accelerators (Cmd+N/O/S/Shift+S)
- **Save / Save As**: renderer-initiated via `onMenuSave` / `onMenuSaveAs` — renderer passes the full `Project` object to main via IPC invoke, main writes JSON and returns the chosen file path
- **Open**: main-initiated — main shows the dialog, reads and parses the file, sends `project:opened` to the renderer which replaces the entire project state and selects the first slide
- **Dirty tracking**: every project mutation auto-sets `isDirty: true` (detected by comparing `project` reference before/after reducer); `isDirty` is synced to main via `notifyDirty()` so the close handler can act on it
- **Title bar**: shows `Lights — <filename> •` when dirty, clears the dot on save, resets to `Lights` on New
- **Close with unsaved changes**: native `showMessageBox` sheet with Save / Don't Save / Cancel; "Save" path sends `menu:save-and-quit` to renderer, renderer saves then calls `confirmQuit()` which triggers `win.destroy()`
- **Image layers** are already stored as base64 data URLs so the JSON file is fully self-contained

## Test plan
- [ ] Cmd+S on a fresh project shows Save dialog, writes `.json` file
- [ ] Title bar updates to filename and clears `•` after save
- [ ] Making a change sets `•` in title
- [ ] Cmd+S with existing file path saves in place (no dialog)
- [ ] Cmd+Shift+S always shows dialog
- [ ] Cmd+O opens a saved file and restores slides/surfaces/layers
- [ ] Image layers survive round-trip (base64 embedded)
- [ ] Closing with unsaved changes shows native confirmation sheet
- [ ] "Don't Save" in sheet closes without saving; "Cancel" stays open
- [ ] Cmd+N resets to empty project (confirms if dirty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)