### PR TITLE
feat(volumes): Paver — 3D projection-mapped volume with cube editor

### DIFF
--- a/packages/ts/lights/src/App.tsx
+++ b/packages/ts/lights/src/App.tsx
@@ -1,11 +1,19 @@
 import { useState } from 'react';
 import { Canvas, LayerToolbar, SlidePanel, StageOverlay, SurfaceCanvas, SurfacePanel } from './components';
 import { useProject, useGraph } from './model';
+import PaverPanel from './components/PaverPanel';
+import PaverEditor from './components/PaverEditor';
+import type { Paver } from './model/types';
 
 export default function App() {
   const { status } = useGraph();
-  const { state: { surfaceMode } } = useProject();
+  const { state } = useProject();
+  const { surfaceMode, project, selectedSlideId, selectedVolumeId } = state;
   const [showVideo, setShowVideo] = useState(true);
+  const [paverEditorOpen, setPaverEditorOpen] = useState(false);
+
+  const slide = project.slides.find(s => s.id === selectedSlideId);
+  const selectedPaver = slide?.volumes?.find(v => v.id === selectedVolumeId) as Paver | undefined;
 
   // *Claude* : Should slide panel be visible in surface mode ?
   return (
@@ -20,6 +28,13 @@ export default function App() {
             <StageOverlay />
           </div>
         )}
+        {paverEditorOpen && selectedPaver && selectedSlideId && (
+          <PaverEditor
+            paver={selectedPaver}
+            slideId={selectedSlideId}
+            onClose={() => setPaverEditorOpen(false)}
+          />
+        )}
         <button
           className={`canvas-video-toggle${showVideo ? '' : ' off'}`}
           title={showVideo ? 'Hide video' : 'Show video'}
@@ -30,7 +45,15 @@ export default function App() {
         <span className="status">{status}</span>
       </div>
       <LayerToolbar />
-      <SurfacePanel />
+      {selectedPaver && selectedSlideId ? (
+        <PaverPanel
+          paver={selectedPaver}
+          slideId={selectedSlideId}
+          onOpenEditor={() => setPaverEditorOpen(true)}
+        />
+      ) : (
+        <SurfacePanel />
+      )}
     </div>
   );
 }

--- a/packages/ts/lights/src/app.css
+++ b/packages/ts/lights/src/app.css
@@ -720,3 +720,109 @@ html, body, #root {
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
+
+/* ── Paver panel ─────────────────────────────────────────────────────────── */
+
+.paver-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.paver-cubes-section {
+  padding: 8px 12px 4px;
+}
+
+.paver-cubes-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  color: #888;
+  margin-bottom: 4px;
+}
+
+.paver-cube-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.paver-cube-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  background: #1e1e1e;
+}
+
+.paver-cube-label {
+  color: #aaa;
+}
+
+.paver-editor-btn-row {
+  padding: 8px 12px;
+}
+
+.paver-open-editor-btn {
+  width: 100%;
+  padding: 6px 0;
+  background: #1e3a5f;
+  border: 1px solid #2d5a8e;
+  border-radius: 4px;
+  color: #93c5fd;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.paver-open-editor-btn:hover {
+  background: #2d5a8e;
+}
+
+.surface-editor-input {
+  width: 100%;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 3px;
+  color: #ccc;
+  font-size: 12px;
+  padding: 3px 6px;
+  margin-bottom: 4px;
+  box-sizing: border-box;
+}
+
+/* ── Paver editor overlay ────────────────────────────────────────────────── */
+
+.paver-editor-overlay {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 420px;
+  background: #111;
+  border-left: 1px solid #2a2a2a;
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+}
+
+.paver-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid #2a2a2a;
+  font-size: 12px;
+  color: #aaa;
+}
+
+.paver-editor-title {
+  color: #fbbf24;
+}
+
+.paver-editor-canvas {
+  flex: 1;
+  min-height: 0;
+}

--- a/packages/ts/lights/src/components/Canvas.tsx
+++ b/packages/ts/lights/src/components/Canvas.tsx
@@ -11,6 +11,9 @@ import {
   frameRect,
 } from './canvas/landmarks';
 import { preloadSurfaces } from '../shaders/homography';
+import { buildPaverRenderState, renderPaver } from '../shaders/paver';
+import type { PaverRenderState } from '../shaders/paver';
+import type { Paver } from '../model/types';
 
 /**
  * Main stage canvas: renders the live camera frame as a WebGL texture, overlays
@@ -21,6 +24,8 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const renderRef = useRef<() => void>(() => {});
   const surfaceGroupRef = useRef<THREE.Group | null>(null);
+  const paverGroupRef = useRef<THREE.Group | null>(null);
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
 
   const showVideoRef = useRef(showVideo);
   showVideoRef.current = showVideo;
@@ -33,6 +38,11 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
     [project.slides, selectedSlideId],
   );
 
+  const volumes = useMemo(
+    () => project.slides.find((s) => s.id === selectedSlideId)?.volumes ?? [],
+    [project.slides, selectedSlideId],
+  );
+
   // ── WebGL setup (runs once) ───────────────────────────────────────────────
   useEffect(() => {
     const container = containerRef.current!;
@@ -41,6 +51,7 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(container.clientWidth, container.clientHeight);
     container.appendChild(renderer.domElement);
+    rendererRef.current = renderer;
 
     // 2D overlay for landmarks — appended after WebGL canvas so it sits on top
     const overlay = document.createElement('canvas');
@@ -64,6 +75,10 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
     const surfaceGroup = new THREE.Group();
     scene.add(surfaceGroup);
     surfaceGroupRef.current = surfaceGroup;
+
+    const paverGroup = new THREE.Group();
+    scene.add(paverGroup);
+    paverGroupRef.current = paverGroup;
 
     const render = () => {
       mesh.visible = showVideoRef.current;
@@ -165,6 +180,7 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
       material.dispose();
       texture.dispose();
       renderer.dispose();
+      rendererRef.current = null;
       container.removeChild(renderer.domElement);
       container.removeChild(overlay);
     };
@@ -193,6 +209,48 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
       group.clear();
     };
   }, [surfaces]);
+
+  // ── Paver render targets (rebuilt when volumes change) ────────────────────
+  useEffect(() => {
+    const group = paverGroupRef.current;
+    const renderer = rendererRef.current;
+    if (!group || !renderer) return;
+
+    const container = containerRef.current!;
+    const stageW = container.clientWidth;
+    const stageH = container.clientHeight;
+
+    const states = new Map<string, PaverRenderState>();
+    const planes: THREE.Mesh[] = [];
+
+    // Build a full-screen quad per paver that samples the render target
+    const screenGeo = new THREE.PlaneGeometry(2, 2);
+    const orthoCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+    for (const volume of volumes as Paver[]) {
+      const ps = buildPaverRenderState(volume, stageW, stageH);
+      states.set(volume.id, ps);
+      renderPaver(volume, ps, renderer);
+
+      const mat = new THREE.MeshBasicMaterial({
+        map: ps.target.texture,
+        transparent: true,
+        depthTest: false,
+      });
+      const plane = new THREE.Mesh(screenGeo, mat);
+      group.add(plane);
+      planes.push(plane);
+    }
+
+    renderRef.current();
+
+    return () => {
+      states.forEach(ps => ps.dispose());
+      planes.forEach(p => (p.material as THREE.Material).dispose());
+      group.clear();
+      screenGeo.dispose();
+    };
+  }, [volumes]);
 
   return <div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }} />;
 }

--- a/packages/ts/lights/src/components/PaverEditor.tsx
+++ b/packages/ts/lights/src/components/PaverEditor.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useRef } from 'react'
+import * as THREE from 'three'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import { useProject } from '../model/ProjectContext'
+import type { Paver } from '../model/types'
+
+interface Props {
+  paver: Paver
+  slideId: string
+  onClose: () => void
+}
+
+export default function PaverEditor({ paver, slideId, onClose }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const { dispatch } = useProject()
+
+  // Use a ref for the latest paver so the event handlers stay current without
+  // re-running the heavy Three.js setup.
+  const paverRef = useRef(paver)
+  paverRef.current = paver
+
+  useEffect(() => {
+    const container = containerRef.current!
+    const { width: w, height: h, depth: d } = paver.dimensions
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true })
+    renderer.setPixelRatio(window.devicePixelRatio)
+    renderer.setSize(container.clientWidth, container.clientHeight)
+    renderer.setClearColor(0x1a1a2e)
+    container.appendChild(renderer.domElement)
+
+    const scene = new THREE.Scene()
+    const camera = new THREE.PerspectiveCamera(50, container.clientWidth / container.clientHeight, 0.01, 500)
+    camera.position.set(w * 1.5, h * 1.5, d * 2.5)
+    camera.lookAt(0, 0, 0)
+
+    const controls = new OrbitControls(camera, renderer.domElement)
+    controls.enableDamping = true
+    controls.target.set(0, 0, 0)
+
+    // Grid at y = -h/2 (floor of bounding box)
+    const grid = new THREE.GridHelper(Math.max(w, d) * 3, 20, 0x444466, 0x333355)
+    grid.position.y = -h / 2
+    scene.add(grid)
+
+    // Ambient + directional light
+    scene.add(new THREE.AmbientLight(0xffffff, 0.6))
+    const dir = new THREE.DirectionalLight(0xffffff, 0.8)
+    dir.position.set(w, h * 2, d * 2)
+    scene.add(dir)
+
+    // Bounding box wireframe
+    const boxGeo = new THREE.BoxGeometry(w, h, d)
+    const edges = new THREE.EdgesGeometry(boxGeo)
+    const wireframe = new THREE.LineSegments(edges, new THREE.LineBasicMaterial({ color: 0x888888 }))
+    scene.add(wireframe)
+    boxGeo.dispose()
+
+    // Cube group — rebuilt when cubes change
+    const cubeGroup = new THREE.Group()
+    scene.add(cubeGroup)
+
+    function rebuildCubes() {
+      cubeGroup.clear()
+      for (const cube of paverRef.current.cubes) {
+        const geo = new THREE.BoxGeometry(1, 1, 1)
+        const mat = new THREE.MeshLambertMaterial({ color: 0x4a90d9 })
+        const mesh = new THREE.Mesh(geo, mat)
+        mesh.position.set(...cube.position)
+        mesh.userData = { cubeId: cube.id }
+        cubeGroup.add(mesh)
+      }
+    }
+    rebuildCubes()
+
+    // Drag state
+    let dragCubeId: string | null = null
+    let dragPlane: THREE.Plane | null = null
+    const raycaster = new THREE.Raycaster()
+    const mouse = new THREE.Vector2()
+
+    function getMouseNDC(e: MouseEvent) {
+      const rect = container.getBoundingClientRect()
+      mouse.set(
+        ((e.clientX - rect.left) / rect.width) * 2 - 1,
+        -((e.clientY - rect.top) / rect.height) * 2 + 1,
+      )
+    }
+
+    function onMouseDown(e: MouseEvent) {
+      if (e.button !== 0) return
+      getMouseNDC(e)
+      raycaster.setFromCamera(mouse, camera)
+
+      // Check for cube hit first
+      const cubeHits = raycaster.intersectObjects(cubeGroup.children)
+      if (cubeHits.length > 0) {
+        controls.enabled = false
+        const mesh = cubeHits[0].object as THREE.Mesh
+        dragCubeId = mesh.userData.cubeId as string
+        // Drag plane: horizontal (y = cube center y)
+        dragPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -mesh.position.y)
+        return
+      }
+
+      // Grid hit → place cube
+      const gridHit = raycaster.intersectObject(grid)
+      if (gridHit.length > 0) {
+        const pt = gridHit[0].point
+        // Snap to integer units
+        const pos: [number, number, number] = [
+          Math.round(pt.x),
+          Math.round(-h/2 + 0.5),  // sit on floor
+          Math.round(pt.z),
+        ]
+        dispatch({ type: 'volume:addCube', slideId, volumeId: paverRef.current.id, position: pos })
+      }
+    }
+
+    function onMouseMove(e: MouseEvent) {
+      if (!dragCubeId || !dragPlane) return
+      getMouseNDC(e)
+      raycaster.setFromCamera(mouse, camera)
+      const pt = new THREE.Vector3()
+      raycaster.ray.intersectPlane(dragPlane, pt)
+      if (!pt) return
+      const mesh = cubeGroup.children.find(c => c.userData.cubeId === dragCubeId) as THREE.Mesh | undefined
+      if (mesh) mesh.position.set(pt.x, mesh.position.y, pt.z)
+    }
+
+    function onMouseUp() {
+      if (!dragCubeId) return
+      const mesh = cubeGroup.children.find(c => c.userData.cubeId === dragCubeId) as THREE.Mesh | undefined
+      if (mesh) {
+        dispatch({
+          type: 'volume:moveCube',
+          slideId,
+          volumeId: paverRef.current.id,
+          cubeId: dragCubeId,
+          position: [mesh.position.x, mesh.position.y, mesh.position.z],
+        })
+      }
+      dragCubeId = null
+      dragPlane = null
+      controls.enabled = true
+    }
+
+    renderer.domElement.addEventListener('mousedown', onMouseDown)
+    renderer.domElement.addEventListener('mousemove', onMouseMove)
+    renderer.domElement.addEventListener('mouseup', onMouseUp)
+
+    let animId = 0
+    function animate() {
+      animId = requestAnimationFrame(animate)
+      controls.update()
+      rebuildCubes()
+      renderer.render(scene, camera)
+    }
+    animate()
+
+    const observer = new ResizeObserver(() => {
+      renderer.setSize(container.clientWidth, container.clientHeight)
+      camera.aspect = container.clientWidth / container.clientHeight
+      camera.updateProjectionMatrix()
+    })
+    observer.observe(container)
+
+    return () => {
+      cancelAnimationFrame(animId)
+      observer.disconnect()
+      renderer.domElement.removeEventListener('mousedown', onMouseDown)
+      renderer.domElement.removeEventListener('mousemove', onMouseMove)
+      renderer.domElement.removeEventListener('mouseup', onMouseUp)
+      controls.dispose()
+      renderer.dispose()
+      container.removeChild(renderer.domElement)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paver.id, paver.dimensions])
+
+  return (
+    <div className="paver-editor-overlay">
+      <div className="paver-editor-header">
+        <span className="paver-editor-title">{paver.name} — 3D Editor</span>
+        <button className="icon-btn" onClick={onClose}>×</button>
+      </div>
+      <div ref={containerRef} className="paver-editor-canvas" />
+    </div>
+  )
+}

--- a/packages/ts/lights/src/components/PaverPanel.tsx
+++ b/packages/ts/lights/src/components/PaverPanel.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+import { useProject } from '../model/ProjectContext'
+import type { Paver, PaverDimensions } from '../model/types'
+
+interface Props {
+  paver: Paver
+  slideId: string
+  onOpenEditor: () => void
+}
+
+export default function PaverPanel({ paver, slideId, onOpenEditor }: Props) {
+  const { dispatch } = useProject()
+  const [editingName, setEditingName] = useState(false)
+  const [nameValue, setNameValue] = useState('')
+
+  function commitName() {
+    const trimmed = nameValue.trim()
+    if (trimmed) dispatch({ type: 'volume:rename', slideId, volumeId: paver.id, name: trimmed })
+    setEditingName(false)
+  }
+
+  function setDim(field: keyof PaverDimensions, raw: string) {
+    const v = parseFloat(raw)
+    if (!isNaN(v) && v > 0) {
+      dispatch({
+        type: 'volume:updateDimensions',
+        slideId,
+        volumeId: paver.id,
+        dimensions: { ...paver.dimensions, [field]: v },
+      })
+    }
+  }
+
+  const { width, height, depth } = paver.dimensions
+
+  return (
+    <div className="paver-panel">
+      <div className="surface-panel-header">
+        {editingName ? (
+          <input
+            autoFocus
+            className="rename-input"
+            value={nameValue}
+            onFocus={e => e.target.select()}
+            onChange={e => setNameValue(e.target.value)}
+            onBlur={commitName}
+            onKeyDown={e => {
+              if (e.key === 'Enter') e.currentTarget.blur()
+              if (e.key === 'Escape') setEditingName(false)
+            }}
+          />
+        ) : (
+          <span
+            className="surface-panel-title"
+            onClick={() => { setNameValue(paver.name); setEditingName(true) }}
+          >
+            {paver.name}
+          </span>
+        )}
+      </div>
+
+      <div className="surface-editor">
+        <label className="surface-editor-label">Width</label>
+        <input
+          type="number" min="0.01" step="0.1"
+          className="surface-editor-input"
+          defaultValue={width}
+          key={`w-${paver.id}`}
+          onBlur={e => setDim('width', e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') e.currentTarget.blur() }}
+        />
+        <label className="surface-editor-label">Height</label>
+        <input
+          type="number" min="0.01" step="0.1"
+          className="surface-editor-input"
+          defaultValue={height}
+          key={`h-${paver.id}`}
+          onBlur={e => setDim('height', e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') e.currentTarget.blur() }}
+        />
+        <label className="surface-editor-label">Depth</label>
+        <input
+          type="number" min="0.01" step="0.1"
+          className="surface-editor-input"
+          defaultValue={depth}
+          key={`d-${paver.id}`}
+          onBlur={e => setDim('depth', e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') e.currentTarget.blur() }}
+        />
+      </div>
+
+      <div className="paver-cubes-section">
+        <div className="paver-cubes-header">
+          <span>Cubes ({paver.cubes.length})</span>
+          <button className="icon-btn" title="Open 3D editor" onClick={onOpenEditor}>
+            ⬡
+          </button>
+        </div>
+        {paver.cubes.length === 0 ? (
+          <p className="panel-empty">No cubes — open editor to place</p>
+        ) : (
+          <div className="paver-cube-list">
+            {paver.cubes.map((cube, i) => (
+              <div key={cube.id} className="paver-cube-item">
+                <span className="paver-cube-label">
+                  Cube {i + 1} ({cube.position.map(n => n.toFixed(1)).join(', ')})
+                </span>
+                <button
+                  className="icon-btn surface-remove"
+                  title="Remove cube"
+                  onClick={() => dispatch({ type: 'volume:removeCube', slideId, volumeId: paver.id, cubeId: cube.id })}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="paver-editor-btn-row">
+        <button className="paver-open-editor-btn" onClick={onOpenEditor}>
+          Open 3D Editor
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/ts/lights/src/components/PaverStageHandles.tsx
+++ b/packages/ts/lights/src/components/PaverStageHandles.tsx
@@ -28,6 +28,17 @@ export default function PaverStageHandles({ paver, slideId, svgRef }: Props) {
   const [size, setSize] = useState({ w: 0, h: 0 })
   const [drag, setDrag] = useState<DragState>(null)
 
+  // Keep a ref so imperative handlers always see the latest drag without
+  // being recreated on every state change (stale closure prevention).
+  const dragRef = useRef<DragState>(null)
+  dragRef.current = drag
+
+  // Keep stable refs to props used in imperative handlers
+  const paverRef = useRef(paver)
+  paverRef.current = paver
+  const slideIdRef = useRef(slideId)
+  slideIdRef.current = slideId
+
   useEffect(() => {
     const svg = svgRef.current
     if (!svg) return
@@ -37,6 +48,56 @@ export default function PaverStageHandles({ paver, slideId, svgRef }: Props) {
     obs.observe(svg)
     return () => obs.disconnect()
   }, [svgRef])
+
+  // Attach pointermove / pointerup directly on the SVG so they fire even when
+  // the pointer moves fast outside the <g> element. The SVG owns the pointer
+  // capture (set in onCornerDown), so these always receive events during a drag.
+  useEffect(() => {
+    const svg = svgRef.current
+    if (!svg) return
+
+    function toNorm(clientX: number, clientY: number): Point {
+      const rect = svg!.getBoundingClientRect()
+      return {
+        x: Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)),
+        y: Math.max(0, Math.min(1, (clientY - rect.top) / rect.height)),
+      }
+    }
+
+    function onMove(e: PointerEvent) {
+      const d = dragRef.current
+      if (!d) return
+      const pt = toNorm(e.clientX, e.clientY)
+      const livePt: Point = {
+        x: Math.max(0, Math.min(1, d.startCorner.x + pt.x - d.startPt.x)),
+        y: Math.max(0, Math.min(1, d.startCorner.y + pt.y - d.startPt.y)),
+      }
+      const next = { ...d, livePt }
+      dragRef.current = next
+      setDrag(next)
+    }
+
+    function onUp() {
+      const d = dragRef.current
+      if (!d) return
+      dispatch({
+        type: 'volume:updateCorner',
+        slideId: slideIdRef.current,
+        volumeId: paverRef.current.id,
+        cornerIdx: d.cornerIdx,
+        point: d.livePt,
+      })
+      dragRef.current = null
+      setDrag(null)
+    }
+
+    svg.addEventListener('pointermove', onMove)
+    svg.addEventListener('pointerup', onUp)
+    return () => {
+      svg.removeEventListener('pointermove', onMove)
+      svg.removeEventListener('pointerup', onUp)
+    }
+  }, [svgRef, dispatch])
 
   function toNorm(clientX: number, clientY: number): Point {
     const rect = svgRef.current!.getBoundingClientRect()
@@ -52,34 +113,14 @@ export default function PaverStageHandles({ paver, slideId, svgRef }: Props) {
 
   function onCornerDown(e: ReactPointerEvent, idx: number) {
     e.stopPropagation()
+    // Capture on the SVG so pointermove/pointerup fire on it even when the
+    // pointer moves outside any child element.
     svgRef.current!.setPointerCapture(e.pointerId)
     if (!selected) dispatch({ type: 'volume:select', volumeId: paver.id })
     const startPt = toNorm(e.clientX, e.clientY)
-    setDrag({ cornerIdx: idx, startPt, startCorner: paver.stageCorners[idx], livePt: paver.stageCorners[idx] })
-  }
-
-  function onPointerMove(e: ReactPointerEvent<SVGSVGElement>) {
-    if (!drag) return
-    const pt = toNorm(e.clientX, e.clientY)
-    const dx = pt.x - drag.startPt.x
-    const dy = pt.y - drag.startPt.y
-    const livePt: Point = {
-      x: Math.max(0, Math.min(1, drag.startCorner.x + dx)),
-      y: Math.max(0, Math.min(1, drag.startCorner.y + dy)),
-    }
-    setDrag({ ...drag, livePt })
-  }
-
-  function onPointerUp() {
-    if (!drag) return
-    dispatch({
-      type: 'volume:updateCorner',
-      slideId,
-      volumeId: paver.id,
-      cornerIdx: drag.cornerIdx,
-      point: drag.livePt,
-    })
-    setDrag(null)
+    const next: DragState = { cornerIdx: idx, startPt, startCorner: paver.stageCorners[idx], livePt: paver.stageCorners[idx] }
+    dragRef.current = next
+    setDrag(next)
   }
 
   function onBodyDown(e: ReactPointerEvent) {
@@ -97,10 +138,7 @@ export default function PaverStageHandles({ paver, slideId, svgRef }: Props) {
   const frontPts = corners.slice(0, 4).map(p => { const q = toPx(p); return `${q.x},${q.y}` }).join(' ')
 
   return (
-    <g
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-    >
+    <g>
       {/* Body hit target (front face polygon) */}
       <polygon
         points={frontPts}
@@ -137,7 +175,7 @@ export default function PaverStageHandles({ paver, slideId, svgRef }: Props) {
             fill={selected ? (isFront ? '#fbbf24' : '#92400e') : '#3a3a3a'}
             stroke={selected ? '#fff' : '#666'}
             strokeWidth={1.5}
-            style={{ cursor: 'grab' }}
+            style={{ cursor: drag ? 'grabbing' : 'grab' }}
             onPointerDown={e => onCornerDown(e, idx)}
           />
         )

--- a/packages/ts/lights/src/components/PaverStageHandles.tsx
+++ b/packages/ts/lights/src/components/PaverStageHandles.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+import { useProject } from '../model/ProjectContext'
+import type { Paver, Point } from '../model/types'
+
+interface Props {
+  paver: Paver
+  slideId: string
+  svgRef: React.RefObject<SVGSVGElement | null>
+}
+
+type DragState = {
+  cornerIdx: number
+  startPt: Point
+  startCorner: Point
+  livePt: Point
+} | null
+
+const FRONT_EDGES: [number, number][] = [[0,1],[1,2],[2,3],[3,0]]
+const BACK_EDGES:  [number, number][] = [[4,5],[5,6],[6,7],[7,4]]
+const SIDE_EDGES:  [number, number][] = [[0,4],[1,5],[2,6],[3,7]]
+
+export default function PaverStageHandles({ paver, slideId, svgRef }: Props) {
+  const { state, dispatch } = useProject()
+  const { selectedVolumeId } = state
+  const selected = paver.id === selectedVolumeId
+
+  const [size, setSize] = useState({ w: 0, h: 0 })
+  const [drag, setDrag] = useState<DragState>(null)
+
+  useEffect(() => {
+    const svg = svgRef.current
+    if (!svg) return
+    const obs = new ResizeObserver(([e]) =>
+      setSize({ w: e.contentRect.width, h: e.contentRect.height })
+    )
+    obs.observe(svg)
+    return () => obs.disconnect()
+  }, [svgRef])
+
+  function toNorm(clientX: number, clientY: number): Point {
+    const rect = svgRef.current!.getBoundingClientRect()
+    return {
+      x: Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)),
+      y: Math.max(0, Math.min(1, (clientY - rect.top) / rect.height)),
+    }
+  }
+
+  function toPx(p: Point) {
+    return { x: p.x * size.w, y: p.y * size.h }
+  }
+
+  function onCornerDown(e: ReactPointerEvent, idx: number) {
+    e.stopPropagation()
+    svgRef.current!.setPointerCapture(e.pointerId)
+    if (!selected) dispatch({ type: 'volume:select', volumeId: paver.id })
+    const startPt = toNorm(e.clientX, e.clientY)
+    setDrag({ cornerIdx: idx, startPt, startCorner: paver.stageCorners[idx], livePt: paver.stageCorners[idx] })
+  }
+
+  function onPointerMove(e: ReactPointerEvent<SVGSVGElement>) {
+    if (!drag) return
+    const pt = toNorm(e.clientX, e.clientY)
+    const dx = pt.x - drag.startPt.x
+    const dy = pt.y - drag.startPt.y
+    const livePt: Point = {
+      x: Math.max(0, Math.min(1, drag.startCorner.x + dx)),
+      y: Math.max(0, Math.min(1, drag.startCorner.y + dy)),
+    }
+    setDrag({ ...drag, livePt })
+  }
+
+  function onPointerUp() {
+    if (!drag) return
+    dispatch({
+      type: 'volume:updateCorner',
+      slideId,
+      volumeId: paver.id,
+      cornerIdx: drag.cornerIdx,
+      point: drag.livePt,
+    })
+    setDrag(null)
+  }
+
+  function onBodyDown(e: ReactPointerEvent) {
+    e.stopPropagation()
+    dispatch({ type: 'volume:select', volumeId: paver.id })
+  }
+
+  if (size.w === 0) return null
+
+  const corners = paver.stageCorners.map((p, i) =>
+    drag?.cornerIdx === i ? drag.livePt : p
+  )
+
+  const allEdges = [...FRONT_EDGES, ...BACK_EDGES, ...SIDE_EDGES]
+  const frontPts = corners.slice(0, 4).map(p => { const q = toPx(p); return `${q.x},${q.y}` }).join(' ')
+
+  return (
+    <g
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    >
+      {/* Body hit target (front face polygon) */}
+      <polygon
+        points={frontPts}
+        fill={selected ? 'rgba(251,191,36,0.1)' : 'rgba(255,255,255,0.04)'}
+        stroke="none"
+        style={{ cursor: 'move' }}
+        onPointerDown={onBodyDown}
+      />
+
+      {/* Edges */}
+      {allEdges.map(([a, b], i) => {
+        const pa = toPx(corners[a]), pb = toPx(corners[b])
+        return (
+          <line
+            key={i}
+            x1={pa.x} y1={pa.y} x2={pb.x} y2={pb.y}
+            stroke={selected ? '#fbbf24' : '#666'}
+            strokeWidth={selected ? 1.5 : 1}
+            strokeDasharray={i >= 8 ? '4 3' : undefined}
+            style={{ pointerEvents: 'none' }}
+          />
+        )
+      })}
+
+      {/* Corner handles */}
+      {corners.map((p, idx) => {
+        const { x, y } = toPx(p)
+        const isFront = idx < 4
+        return (
+          <circle
+            key={idx}
+            cx={x} cy={y}
+            r={isFront ? 6 : 4}
+            fill={selected ? (isFront ? '#fbbf24' : '#92400e') : '#3a3a3a'}
+            stroke={selected ? '#fff' : '#666'}
+            strokeWidth={1.5}
+            style={{ cursor: 'grab' }}
+            onPointerDown={e => onCornerDown(e, idx)}
+          />
+        )
+      })}
+
+      {/* Label */}
+      {(() => {
+        const c = corners.slice(0,4).reduce((acc, p) => ({ x: acc.x + p.x/4, y: acc.y + p.y/4 }), { x: 0, y: 0 })
+        const cPx = toPx(c)
+        return (
+          <text
+            x={cPx.x} y={cPx.y}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize={11} fill={selected ? '#fbbf24' : '#666'}
+            style={{ pointerEvents: 'none', userSelect: 'none' }}
+          >
+            {paver.name}
+          </text>
+        )
+      })()}
+    </g>
+  )
+}

--- a/packages/ts/lights/src/components/StageOverlay.tsx
+++ b/packages/ts/lights/src/components/StageOverlay.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { PointerEvent as ReactPointerEvent } from 'react'
 import { useProject } from '../model/ProjectContext'
 import type { Surface, Point } from '../model/types'
+import PaverStageHandles from './PaverStageHandles'
 
 // Session-only surface clipboard — not persisted in project state.
 let surfaceClipboard: Surface | null = null
@@ -101,6 +102,7 @@ export default function StageOverlay() {
   const { project, selectedSlideId, selectedSurfaceId } = state
   const slide = project.slides.find(s => s.id === selectedSlideId)
   const surfaces = slide?.surfaces ?? []
+  const volumes = slide?.volumes ?? []
 
   // ── Arrow key nudge ────────────────────────────────────────────────────────
   useEffect(() => {
@@ -246,6 +248,14 @@ export default function StageOverlay() {
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
     >
+      {volumes.map(volume => (
+        <PaverStageHandles
+          key={volume.id}
+          paver={volume}
+          slideId={selectedSlideId!}
+          svgRef={svgRef}
+        />
+      ))}
       {surfaces.map(surface => {
         const polygon = drag?.surfaceId === surface.id ? drag.livePolygon : surface.outputPolygon
         const selected = surface.id === selectedSurfaceId

--- a/packages/ts/lights/src/components/SurfacePanel.tsx
+++ b/packages/ts/lights/src/components/SurfacePanel.tsx
@@ -13,7 +13,7 @@ import GraphConfigPanel from './GraphConfigPanel'
  */
 export default function SurfacePanel() {
   const { state, dispatch } = useProject()
-  const { project, selectedSlideId, selectedSurfaceId, selectedLayerId, surfaceMode } = state
+  const { project, selectedSlideId, selectedSurfaceId, selectedLayerId, surfaceMode, selectedVolumeId } = state
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editValue, setEditValue] = useState('')
 
@@ -31,6 +31,7 @@ export default function SurfacePanel() {
 
   const slide = project.slides.find(s => s.id === selectedSlideId)
   const surfaces = slide?.surfaces ?? []
+  const volumes = slide?.volumes ?? []
   const surface = surfaces.find(s => s.id === selectedSurfaceId)
 
   // ── Surface mode: layer panel ─────────────────────────────────────────────
@@ -184,6 +185,43 @@ export default function SurfacePanel() {
                 onClick={e => {
                   e.stopPropagation()
                   dispatch({ type: 'surface:remove', slideId: selectedSlideId!, surfaceId: s.id })
+                }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="surface-panel-header" style={{ marginTop: 8 }}>
+        <span>Volumes</span>
+        {selectedSlideId && (
+          <button
+            className="icon-btn"
+            title="Add paver"
+            onClick={() => dispatch({ type: 'volume:add', slideId: selectedSlideId })}
+          >
+            +
+          </button>
+        )}
+      </div>
+
+      {selectedSlideId && volumes.length > 0 && (
+        <div className="surface-list">
+          {volumes.map(v => (
+            <div
+              key={v.id}
+              className={`surface-item${v.id === selectedVolumeId ? ' selected' : ''}`}
+              onClick={() => dispatch({ type: 'volume:select', volumeId: v.id })}
+            >
+              <span className="surface-name">{v.name}</span>
+              <button
+                className="icon-btn surface-remove"
+                title="Remove volume"
+                onClick={e => {
+                  e.stopPropagation()
+                  dispatch({ type: 'volume:remove', slideId: selectedSlideId!, volumeId: v.id })
                 }}
               >
                 ×

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useReducer, useRef } from 'react'
 import type { Dispatch, ReactNode } from 'react'
-import type { ImageLayer, Layer, Project, Slide, Surface, TextLayer } from './types'
+import type { ImageLayer, Layer, Paver, PaverDimensions, Project, Slide, Surface, TextLayer, Volume } from './types'
+import { defaultPaverCorners } from './paver'
 
 // ── State ────────────────────────────────────────────────────────────────────
 
@@ -9,6 +10,7 @@ export interface ProjectState {
   selectedSlideId: string | null
   selectedSurfaceId: string | null
   selectedLayerId: string | null
+  selectedVolumeId: string | null
   surfaceMode: boolean  // true = flat local editor open
   isDirty: boolean
   currentFilePath: string | null
@@ -19,6 +21,7 @@ const initial: ProjectState = {
   selectedSlideId: null,
   selectedSurfaceId: null,
   selectedLayerId: null,
+  selectedVolumeId: null,
   surfaceMode: false,
   isDirty: false,
   currentFilePath: null,
@@ -52,6 +55,15 @@ export type ProjectAction =
   | { type: 'layer:select'; layerId: string | null }
   | { type: 'layer:toggle-visibility'; slideId: string; surfaceId: string; layerId: string }
   | { type: 'slide:updateGraphConfig'; slideId: string; config: import('../ipc/types').GraphConfig }
+  | { type: 'volume:add'; slideId: string; dimensions?: PaverDimensions }
+  | { type: 'volume:remove'; slideId: string; volumeId: string }
+  | { type: 'volume:select'; volumeId: string | null }
+  | { type: 'volume:updateCorner'; slideId: string; volumeId: string; cornerIdx: number; point: import('../ipc/types').Point }
+  | { type: 'volume:updateDimensions'; slideId: string; volumeId: string; dimensions: PaverDimensions }
+  | { type: 'volume:rename'; slideId: string; volumeId: string; name: string }
+  | { type: 'volume:addCube'; slideId: string; volumeId: string; position: [number,number,number] }
+  | { type: 'volume:moveCube'; slideId: string; volumeId: string; cubeId: string; position: [number,number,number] }
+  | { type: 'volume:removeCube'; slideId: string; volumeId: string; cubeId: string }
 
 // ── Reducer ──────────────────────────────────────────────────────────────────
 
@@ -74,14 +86,37 @@ function patchSurfaceLayers(
   }
 }
 
+function patchVolume(
+  state: ProjectState,
+  slideId: string,
+  volumeId: string,
+  fn: (v: Volume) => Volume
+): ProjectState {
+  return {
+    ...state,
+    project: {
+      ...state.project,
+      slides: state.project.slides.map(s =>
+        s.id === slideId
+          ? { ...s, volumes: s.volumes.map(v => v.id === volumeId ? fn(v) : v) }
+          : s
+      ),
+    },
+  }
+}
+
 function reducer(state: ProjectState, action: ProjectAction): ProjectState {
   // Project-level actions that manage dirty/path themselves
   if (action.type === 'project:load') {
+    const project: Project = {
+      ...action.project,
+      slides: action.project.slides.map(s => ({ ...s, volumes: s.volumes ?? [] })),
+    }
     return {
       ...initial,
-      project: action.project,
+      project,
       currentFilePath: action.filePath,
-      selectedSlideId: action.project.slides[0]?.id ?? null,
+      selectedSlideId: project.slides[0]?.id ?? null,
     }
   }
   if (action.type === 'project:saved') {
@@ -105,6 +140,7 @@ function projectMutationReducer(state: ProjectState, action: ProjectAction): Pro
         id: crypto.randomUUID(),
         name: `Slide ${project.slides.length + 1}`,
         surfaces: [],
+        volumes: [],
         graphConfig: { modules: {} },
       }
       return {
@@ -127,6 +163,11 @@ function projectMutationReducer(state: ProjectState, action: ProjectAction): Pro
           ...sf,
           id: crypto.randomUUID(),
           layers: sf.layers.map(l => ({ ...l, id: crypto.randomUUID() })),
+        })),
+        volumes: (src.volumes ?? []).map(v => ({
+          ...v,
+          id: crypto.randomUUID(),
+          cubes: (v as Paver).cubes.map(c => ({ ...c, id: crypto.randomUUID() })),
         })),
       }
       const idx = project.slides.findIndex(s => s.id === action.slideId)
@@ -156,7 +197,7 @@ function projectMutationReducer(state: ProjectState, action: ProjectAction): Pro
     }
 
     case 'slide:select':
-      return { ...state, selectedSlideId: action.slideId, selectedSurfaceId: null, selectedLayerId: null, surfaceMode: false }
+      return { ...state, selectedSlideId: action.slideId, selectedSurfaceId: null, selectedLayerId: null, selectedVolumeId: null, surfaceMode: false }
 
     case 'surface:add': {
       const surface: Surface = {
@@ -226,7 +267,7 @@ function projectMutationReducer(state: ProjectState, action: ProjectAction): Pro
     }
 
     case 'surface:select':
-      return { ...state, selectedSurfaceId: action.surfaceId, selectedLayerId: null, surfaceMode: false }
+      return { ...state, selectedSurfaceId: action.surfaceId, selectedLayerId: null, selectedVolumeId: null, surfaceMode: false }
 
     case 'surface:enter':
       if (!state.selectedSurfaceId) return state
@@ -328,6 +369,89 @@ function projectMutationReducer(state: ProjectState, action: ProjectAction): Pro
           slides: project.slides.map(s => s.id === action.slideId ? { ...s, graphConfig: action.config } : s),
         },
       }
+
+    case 'volume:add': {
+      const slide = project.slides.find(s => s.id === action.slideId)
+      if (!slide) return state
+      const dim: PaverDimensions = action.dimensions ?? { width: 1, height: 1, depth: 1 }
+      const paver: Paver = {
+        id: crypto.randomUUID(),
+        name: `Paver ${(slide.volumes?.length ?? 0) + 1}`,
+        kind: 'paver',
+        dimensions: dim,
+        stageCorners: defaultPaverCorners(dim),
+        cubes: [],
+      }
+      return {
+        ...state,
+        project: {
+          ...project,
+          slides: project.slides.map(s =>
+            s.id === action.slideId ? { ...s, volumes: [...(s.volumes ?? []), paver] } : s
+          ),
+        },
+        selectedVolumeId: paver.id,
+        selectedSurfaceId: null,
+      }
+    }
+
+    case 'volume:remove': {
+      const selectedVolumeId =
+        state.selectedVolumeId === action.volumeId ? null : state.selectedVolumeId
+      return {
+        ...state,
+        project: {
+          ...project,
+          slides: project.slides.map(s =>
+            s.id === action.slideId
+              ? { ...s, volumes: (s.volumes ?? []).filter(v => v.id !== action.volumeId) }
+              : s
+          ),
+        },
+        selectedVolumeId,
+      }
+    }
+
+    case 'volume:select':
+      return { ...state, selectedVolumeId: action.volumeId, selectedSurfaceId: null, surfaceMode: false }
+
+    case 'volume:updateCorner':
+      return patchVolume(state, action.slideId, action.volumeId, v => {
+        const paver = v as Paver
+        const corners = [...paver.stageCorners] as typeof paver.stageCorners
+        corners[action.cornerIdx] = action.point
+        return { ...paver, stageCorners: corners }
+      })
+
+    case 'volume:updateDimensions':
+      return patchVolume(state, action.slideId, action.volumeId, v => ({
+        ...(v as Paver),
+        dimensions: action.dimensions,
+      }))
+
+    case 'volume:rename':
+      return patchVolume(state, action.slideId, action.volumeId, v => ({
+        ...v,
+        name: action.name,
+      }))
+
+    case 'volume:addCube':
+      return patchVolume(state, action.slideId, action.volumeId, v => {
+        const paver = v as Paver
+        return { ...paver, cubes: [...paver.cubes, { id: crypto.randomUUID(), position: action.position }] }
+      })
+
+    case 'volume:moveCube':
+      return patchVolume(state, action.slideId, action.volumeId, v => {
+        const paver = v as Paver
+        return { ...paver, cubes: paver.cubes.map(c => c.id === action.cubeId ? { ...c, position: action.position } : c) }
+      })
+
+    case 'volume:removeCube':
+      return patchVolume(state, action.slideId, action.volumeId, v => {
+        const paver = v as Paver
+        return { ...paver, cubes: paver.cubes.filter(c => c.id !== action.cubeId) }
+      })
 
     case 'slide:rename':
       return {

--- a/packages/ts/lights/src/model/paver.ts
+++ b/packages/ts/lights/src/model/paver.ts
@@ -1,0 +1,228 @@
+import * as THREE from 'three'
+import type { PaverCorners, PaverDimensions } from './types'
+
+// ── Linear algebra helpers ───────────────────────────────────────────────────
+
+function dot3(a: number[], b: number[]) { return a[0]*b[0] + a[1]*b[1] + a[2]*b[2] }
+function sub3(a: number[], b: number[]): number[] { return [a[0]-b[0], a[1]-b[1], a[2]-b[2]] }
+function scale3(a: number[], s: number): number[] { return [a[0]*s, a[1]*s, a[2]*s] }
+function norm3(a: number[]) { return Math.sqrt(dot3(a, a)) }
+function normalize3(a: number[]): number[] { const n = norm3(a); return n > 1e-12 ? scale3(a, 1/n) : [0,0,0] }
+
+function mat3Transpose(M: number[][]): number[][] {
+  return [[M[0][0],M[1][0],M[2][0]], [M[0][1],M[1][1],M[2][1]], [M[0][2],M[1][2],M[2][2]]]
+}
+
+function mat3Mul(A: number[][], B: number[][]): number[][] {
+  return Array.from({length: 3}, (_, i) =>
+    Array.from({length: 3}, (_, j) => A[i][0]*B[0][j] + A[i][1]*B[1][j] + A[i][2]*B[2][j])
+  )
+}
+
+function mat3Inv(M: number[][]): number[][] {
+  const d = M[0][0]*(M[1][1]*M[2][2]-M[1][2]*M[2][1])
+           -M[0][1]*(M[1][0]*M[2][2]-M[1][2]*M[2][0])
+           +M[0][2]*(M[1][0]*M[2][1]-M[1][1]*M[2][0])
+  return [
+    [(M[1][1]*M[2][2]-M[1][2]*M[2][1])/d, -(M[0][1]*M[2][2]-M[0][2]*M[2][1])/d,  (M[0][1]*M[1][2]-M[0][2]*M[1][1])/d],
+    [-(M[1][0]*M[2][2]-M[1][2]*M[2][0])/d, (M[0][0]*M[2][2]-M[0][2]*M[2][0])/d, -(M[0][0]*M[1][2]-M[0][2]*M[1][0])/d],
+    [(M[1][0]*M[2][1]-M[1][1]*M[2][0])/d, -(M[0][0]*M[2][1]-M[0][1]*M[2][0])/d,  (M[0][0]*M[1][1]-M[0][1]*M[1][0])/d],
+  ]
+}
+
+// Gaussian elimination (same as homography.ts)
+function gaussianElim(A: number[][], b: number[]): number[] {
+  const n = A.length
+  const M = A.map((row, i) => [...row, b[i]])
+  for (let col = 0; col < n; col++) {
+    let pivot = col
+    for (let row = col + 1; row < n; row++) {
+      if (Math.abs(M[row][col]) > Math.abs(M[pivot][col])) pivot = row
+    }
+    ;[M[col], M[pivot]] = [M[pivot], M[col]]
+    for (let row = col + 1; row < n; row++) {
+      const f = M[row][col] / M[col][col]
+      for (let k = col; k <= n; k++) M[row][k] -= f * M[col][k]
+    }
+  }
+  const x = new Array(n).fill(0)
+  for (let i = n - 1; i >= 0; i--) {
+    x[i] = M[i][n]
+    for (let j = i + 1; j < n; j++) x[i] -= M[i][j] * x[j]
+    x[i] /= M[i][i]
+  }
+  return x
+}
+
+// Overdetermined least squares: (A^T A) x = A^T b
+function leastSquares(A: number[][], b: number[]): number[] {
+  const m = A.length, n = A[0].length
+  const ATA: number[][] = Array.from({length: n}, (_, i) =>
+    Array.from({length: n}, (_, j) => A.reduce((s, row) => s + row[i]*row[j], 0))
+  )
+  const ATb: number[] = Array.from({length: n}, (_, i) =>
+    A.reduce((s, row, k) => s + row[i]*b[k], 0)
+  )
+  return gaussianElim(ATA, ATb)
+}
+
+// QR decomposition via Gram-Schmidt; columns of M are the input vectors
+function qrDecomp(cols: number[][]): { Q: number[][], R: number[][] } {
+  const n = cols.length
+  const es: number[][] = []
+  for (let i = 0; i < n; i++) {
+    let u = [...cols[i]]
+    for (let j = 0; j < i; j++) u = sub3(u, scale3(es[j], dot3(cols[i], es[j])))
+    es.push(normalize3(u))
+  }
+  const Q = [[es[0][0],es[1][0],es[2][0]], [es[0][1],es[1][1],es[2][1]], [es[0][2],es[1][2],es[2][2]]]
+  const A = [[cols[0][0],cols[1][0],cols[2][0]], [cols[0][1],cols[1][1],cols[2][1]], [cols[0][2],cols[1][2],cols[2][2]]]
+  const R = mat3Mul(mat3Transpose(Q), A)
+  return { Q, R }
+}
+
+// RQ decomposition: M = K * Rrot (K upper-triangular, Rrot orthogonal)
+// Via QR of M^{-1}: M^{-1} = Q * Rinv => M = Rinv^{-1} * Q^T = K * Rrot
+function rqDecomp(M: number[][]): { K: number[][], Rrot: number[][] } {
+  const Minv = mat3Inv(M)
+  const cols = [[Minv[0][0],Minv[1][0],Minv[2][0]], [Minv[0][1],Minv[1][1],Minv[2][1]], [Minv[0][2],Minv[1][2],Minv[2][2]]]
+  const { Q, R: Rinv } = qrDecomp(cols)
+
+  // Enforce positive diagonal so K intrinsics are conventional (fx, fy > 0)
+  for (let i = 0; i < 3; i++) {
+    if (Rinv[i][i] < 0) {
+      Rinv[i] = Rinv[i].map(x => -x)
+      for (let j = 0; j < 3; j++) Q[j][i] = -Q[j][i]
+    }
+  }
+
+  return { K: mat3Inv(Rinv), Rrot: mat3Transpose(Q) }
+}
+
+// ── DLT PnP solve ────────────────────────────────────────────────────────────
+
+// Solve for 3×4 projection matrix P from ≥6 2D↔3D correspondences.
+// pts3d in physical units, pts2d in normalised stage [0,1].
+function dltSolve(pts3d: [number,number,number][], pts2d: [number,number][]): number[][] {
+  const A: number[][] = []
+  const b: number[] = []
+  for (let i = 0; i < pts3d.length; i++) {
+    const [X, Y, Z] = pts3d[i]
+    const [x, y] = pts2d[i]
+    A.push([X, Y, Z, 1, 0, 0, 0, 0, -x*X, -x*Y, -x*Z])
+    b.push(x)
+    A.push([0, 0, 0, 0, X, Y, Z, 1, -y*X, -y*Y, -y*Z])
+    b.push(y)
+  }
+  const p = leastSquares(A, b)
+  return [
+    [p[0], p[1], p[2],  p[3]],
+    [p[4], p[5], p[6],  p[7]],
+    [p[8], p[9], p[10], 1   ],
+  ]
+}
+
+// ── Camera from P ────────────────────────────────────────────────────────────
+
+// Build a calibrated Three.js camera from a 3×4 DLT matrix.
+// Uses RQ decomposition: P = K * [R | t]
+export function cameraFromP(P: number[][], near = 0.01, far = 1000): THREE.PerspectiveCamera {
+  const M = [P[0].slice(0,3), P[1].slice(0,3), P[2].slice(0,3)]
+  const p4 = [P[0][3], P[1][3], P[2][3]]
+
+  const { K, Rrot } = rqDecomp(M)
+
+  // Normalise K so K[2][2] = 1
+  const s = K[2][2]
+  const Kn = K.map(row => row.map(x => x/s))
+  const t = mat3Inv(Kn).map(row => row[0]*p4[0] + row[1]*p4[1] + row[2]*p4[2])
+
+  const fx = Kn[0][0], fy = Math.abs(Kn[1][1])  // fy may be negative (Y-flip)
+  const cx = Kn[0][2], cy = Kn[1][2]
+
+  // OpenGL projection for normalised [0,1] image coords.
+  // Camera convention here: +z into scene, Y-down image.
+  // Three.js expects camera looking along -z, so we flip z via the view matrix.
+  const proj = new THREE.Matrix4()
+  proj.set(
+     2*fx,     0,  -(2*cx - 1),              0,
+        0, -2*fy,   (2*cy - 1),              0,
+        0,     0, -(far+near)/(far-near), -2*far*near/(far-near),
+        0,     0,  -1,                        0,
+  )
+
+  // View matrix: apply z-flip so Three.js camera looks along -z while our
+  // convention has +z depth. That means negating row 2 of [R | t].
+  const view = new THREE.Matrix4()
+  view.set(
+     Rrot[0][0],  Rrot[0][1],  Rrot[0][2], t[0],
+     Rrot[1][0],  Rrot[1][1],  Rrot[1][2], t[1],
+    -Rrot[2][0], -Rrot[2][1], -Rrot[2][2], -t[2],
+    0, 0, 0, 1,
+  )
+
+  const cam = new THREE.PerspectiveCamera()
+  cam.matrixAutoUpdate = false
+  cam.projectionMatrix.copy(proj)
+  cam.projectionMatrixInverse.copy(proj).invert()
+  cam.matrixWorldInverse.copy(view)
+  cam.matrixWorld.copy(view).invert()
+  return cam
+}
+
+// ── Bounding box corners ─────────────────────────────────────────────────────
+
+// Returns the 8 3D bounding box corners in the paver's local space.
+// Layout: 0-3 = front face (z=-d/2) TL→TR→BR→BL, 4-7 = back face (z=+d/2)
+export function paverCorners3d(dim: PaverDimensions): [number,number,number][] {
+  const { width: w, height: h, depth: d } = dim
+  const hw = w/2, hh = h/2, hd = d/2
+  return [
+    [-hw,  hh, -hd], [ hw,  hh, -hd], [ hw, -hh, -hd], [-hw, -hh, -hd],
+    [-hw,  hh,  hd], [ hw,  hh,  hd], [ hw, -hh,  hd], [-hw, -hh,  hd],
+  ] as [number,number,number][]
+}
+
+// ── Default stage corners ─────────────────────────────────────────────────────
+
+// Project the bounding box corners through a canonical front-facing camera.
+// The paver is centered on stage at a sensible scale.
+export function defaultPaverCorners(dim: PaverDimensions, stageAspect = 16/9): PaverCorners {
+  const { width: w, height: h, depth: d } = dim
+
+  // Canonical camera: positioned in front of paver along -z, looking along +z.
+  // Vertical FOV 60° → fy_norm = 1/(2·tan30°) ≈ 0.866 (but negative for Y-down stage)
+  const fy = -1 / (2 * Math.tan(Math.PI / 6))        // ≈ -0.866
+  const fx = fy / stageAspect                          // narrower per unit in x
+  const cx = 0.5, cy = 0.5
+
+  // Camera far enough that front face spans ~60 % of stage height
+  const zOffset = Math.abs(fy) * h / 0.6
+
+  // Camera at (0, 0, -(d/2 + zOffset)), R = I, t = (0, 0, d/2 + zOffset)
+  const camZ = d/2 + zOffset
+
+  const pts3d = paverCorners3d(dim)
+  const projected = pts3d.map(([X, Y, Z]) => {
+    const Zc = Z + camZ   // camera space Z (depth)
+    const x = fx * X / Zc + cx
+    const y = fy * Y / Zc + cy
+    return { x, y }
+  })
+
+  return projected as unknown as PaverCorners
+}
+
+// ── Solve camera for a paver ─────────────────────────────────────────────────
+
+export function solvePaverCamera(
+  dim: PaverDimensions,
+  stageCorners: PaverCorners,
+  near = 0.01,
+  far = 1000,
+): THREE.PerspectiveCamera {
+  const pts3d = paverCorners3d(dim) as [number,number,number][]
+  const pts2d = stageCorners.map(p => [p.x, p.y]) as [number,number][]
+  const P = dltSolve(pts3d, pts2d)
+  return cameraFromP(P, near, far)
+}

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -4,6 +4,34 @@ export type { Point, GraphConfig }
 
 export type Polygon = Point[]
 
+// ── Volume types ─────────────────────────────────────────────────────────────
+
+export interface PaverDimensions {
+  width: number   // X, arbitrary units
+  height: number  // Y
+  depth: number   // Z
+}
+
+// 0-3: front face (z = -depth/2) TL→TR→BR→BL
+// 4-7: back face  (z = +depth/2) TL→TR→BR→BL
+export type PaverCorners = [Point, Point, Point, Point, Point, Point, Point, Point]
+
+export interface PaverCube {
+  id: string
+  position: [number, number, number]
+}
+
+export interface Paver {
+  id: string
+  name: string
+  kind: 'paver'
+  dimensions: PaverDimensions
+  stageCorners: PaverCorners
+  cubes: PaverCube[]
+}
+
+export type Volume = Paver
+
 export interface LayerTransform {
   x: number        // center, normalized [0,1]
   y: number        // center, normalized [0,1]
@@ -38,6 +66,7 @@ export interface Slide {
   id: string
   name: string
   surfaces: Surface[]
+  volumes: Volume[]
   graphConfig: GraphConfig
 }
 

--- a/packages/ts/lights/src/shaders/paver.ts
+++ b/packages/ts/lights/src/shaders/paver.ts
@@ -1,0 +1,107 @@
+import * as THREE from 'three'
+import { solvePaverCamera } from '../model/paver'
+import type { Paver } from '../model/types'
+
+const checkerFrag = /* glsl */`
+varying vec2 vUv;
+uniform vec3 uColor;
+void main() {
+  float c = mod(floor(vUv.x * 6.0) + floor(vUv.y * 6.0), 2.0);
+  gl_FragColor = vec4(mix(uColor * 0.55, uColor, c), 0.8);
+}
+`
+
+const checkerVert = /* glsl */`
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`
+
+const CHECKER_COLORS: [number, number, number][] = [
+  [0.38, 0.65, 0.98],
+  [0.37, 0.80, 0.60],
+  [0.98, 0.60, 0.38],
+  [0.80, 0.37, 0.74],
+  [0.98, 0.85, 0.37],
+]
+
+let colorIndex = 0
+
+function checkerMaterial(colorIdx: number): THREE.ShaderMaterial {
+  return new THREE.ShaderMaterial({
+    vertexShader: checkerVert,
+    fragmentShader: checkerFrag,
+    uniforms: { uColor: { value: new THREE.Vector3(...CHECKER_COLORS[colorIdx % CHECKER_COLORS.length]) } },
+    transparent: true,
+    side: THREE.FrontSide,
+    depthTest: true,
+  })
+}
+
+// ── Per-paver render state ────────────────────────────────────────────────────
+
+export interface PaverRenderState {
+  scene: THREE.Scene
+  target: THREE.WebGLRenderTarget
+  colorIdx: number
+  dispose: () => void
+}
+
+export function buildPaverRenderState(paver: Paver, stageW: number, stageH: number): PaverRenderState {
+  const scene = new THREE.Scene()
+  const colorIdx = colorIndex++
+
+  if (paver.cubes.length === 0) {
+    // Show checkerboard on bounding box faces when no cubes placed
+    const { width: w, height: h, depth: d } = paver.dimensions
+    const geo = new THREE.BoxGeometry(w, h, d)
+    const mat = checkerMaterial(colorIdx)
+    const mesh = new THREE.Mesh(geo, mat)
+    scene.add(mesh)
+  } else {
+    const mat = checkerMaterial(colorIdx)
+    for (const cube of paver.cubes) {
+      const geo = new THREE.BoxGeometry(1, 1, 1)
+      const mesh = new THREE.Mesh(geo, mat)
+      mesh.position.set(...cube.position)
+      scene.add(mesh)
+    }
+  }
+
+  const target = new THREE.WebGLRenderTarget(stageW, stageH, {
+    format: THREE.RGBAFormat,
+    depthBuffer: true,
+  })
+
+  return {
+    scene,
+    target,
+    colorIdx,
+    dispose() {
+      scene.traverse(obj => {
+        if (obj instanceof THREE.Mesh) {
+          obj.geometry.dispose()
+          if (Array.isArray(obj.material)) obj.material.forEach(m => m.dispose())
+          else obj.material.dispose()
+        }
+      })
+      target.dispose()
+    },
+  }
+}
+
+export function renderPaver(
+  paver: Paver,
+  state: PaverRenderState,
+  renderer: THREE.WebGLRenderer,
+): void {
+  const cam = solvePaverCamera(paver.dimensions, paver.stageCorners)
+  const prev = renderer.getRenderTarget()
+  renderer.setRenderTarget(state.target)
+  renderer.setClearColor(0x000000, 0)
+  renderer.clear()
+  renderer.render(state.scene, cam)
+  renderer.setRenderTarget(prev)
+}


### PR DESCRIPTION
Closes #43.

## Summary

- **Data model** — `Volume` union type (currently `Paver`) added to `Slide` alongside `Surface`. Backward-compatible: loaded projects without `volumes` get an empty array.
- **DLT PnP math** (`model/paver.ts`) — Overdetermined least-squares (normal equations) from 8 stage ↔ 3D correspondences; RQ decomposition via QR of M⁻¹ to extract K, R, t; builds a calibrated Three.js `PerspectiveCamera` directly (no external lib).
- **Rendering** (`shaders/paver.ts`) — Per-paver `WebGLRenderTarget` at stage resolution; checkerboard `ShaderMaterial` on `BoxGeometry` bounding box when no cubes; full cube rendering when cubes are placed.
- **Stage handles** (`PaverStageHandles.tsx`) — 8 independently draggable SVG corners with front/back/side edges drawn in amber; deselects surfaces on paver click.
- **Right panel** (`PaverPanel.tsx`) — Name, width/height/depth fields, cube list with per-cube remove, "Open 3D Editor" button. Replaces `SurfacePanel` when a paver is selected.
- **3D editor** (`PaverEditor.tsx`) — Three.js viewport alongside the stage (right overlay): orbit controls, grid floor at y=−h/2, bounding box wireframe. Click grid → place cube snapped to integer units. Drag cube → move on horizontal plane.
- **Wiring** — `Canvas.tsx` composites paver render targets; `StageOverlay.tsx` mounts handles; `SurfacePanel.tsx` gets a Volumes section; `App.tsx` conditionally shows `PaverPanel` + editor.

## Test plan

- [ ] Add a slide, click **+** in the Volumes section → Paver 1 appears with default projected bounding box visible on stage
- [ ] 8 corner handles visible; drag each independently → projected box updates live
- [ ] Drag a corner on the back face → back corners move independently from front
- [ ] Empty paver shows checkerboard on bounding box faces (same style as surface fallback)
- [ ] Clicking a paver in stage view selects it and switches right panel to PaverPanel
- [ ] Clicking a surface deselects the paver (and vice versa)
- [ ] Change width/height/depth in PaverPanel → projected shape updates
- [ ] Open 3D editor → paver editor overlay appears alongside the stage
- [ ] In editor: click on grid floor → cube placed; drag cube → moves on horizontal plane
- [ ] Cube appears in cube list in PaverPanel; remove button works
- [ ] Multiple pavers on one slide both render and composite correctly
- [ ] Duplicate slide copies pavers with new IDs
- [ ] Load a project saved before this PR → `volumes` defaults to `[]`, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)