### PR TITLE
feat(volumes): data model + side panel scaffold

### DIFF
--- a/packages/ts/lights/guidelines.md
+++ b/packages/ts/lights/guidelines.md
@@ -249,7 +249,48 @@ Goal: author real content on surfaces and see it live on the projector.
 
 **Done when**: you can build a multi-surface, multi-slide project with real content, save it, reopen it, and see it projected correctly on the output window.
 
-### Milestone 4 — Event Reactions
+### Milestone 4 — Volumes Editor
+
+Goal: add depth to a scene by compositing a 3D scene onto the stage canvas.
+
+A **Volume** is a single 3D scene attached to a slide. It renders as a separate pass on top of
+the flat surfaces, perspective-matched to the real-world projection environment via a virtual
+camera. `VolumeShape` mirrors `Surface`: same `Layer` and `Reaction` types, same mental model.
+
+```ts
+interface Volume {
+  id: string
+  name: string
+  camera: VolumeCamera  // position, target, fov
+  shapes: VolumeShape[]
+}
+
+interface VolumeShape {
+  id: string; name: string; type: 'box' | 'sphere' | 'cylinder' | 'cone'
+  position, rotation, scale: { x, y, z }
+  layers: Layer[]
+  reactions: Reaction[]
+}
+```
+
+`Slide` gains a `volume?: Volume` field. One Volume per slide.
+
+**Camera alignment** — a HUD activated from the side panel. Overlays a fixed two-point
+perspective grid (horizon + two sets of converging lines) on the stage canvas. Arrow controls
+(orbit / pan / dolly / FOV) nudge `Volume.camera` in fixed increments; the 3D scene updates
+live until the grid matches the physical environment.
+
+**Volume editor** — entering a Volume switches the canvas to a free-orbit 3D editor
+(`OrbitControls` + `TransformControls`). Shapes are created, positioned, and deleted here.
+A "View from projector" button snaps the editor camera to `Volume.camera` for a projection
+preview. A ghost frustum shows the projection camera at all times.
+
+**Done when**: you can add a 3D primitive to a slide, align the virtual camera to the physical
+environment, and see the shape rendered correctly in the projected output.
+
+---
+
+### Milestone 5 — Event Reactions
 
 Goal: make the installation interactive — the fun payoff.
 
@@ -262,7 +303,7 @@ Goal: make the installation interactive — the fun payoff.
 
 **Done when**: waving your hand changes something on a specific surface, configured entirely in the UI.
 
-### Milestone 5 — Calibration & Geometry
+### Milestone 6 — Calibration & Geometry
 
 Goal: replace manual surface placement with automatic geometry detection.
 

--- a/packages/ts/lights/src/components/SurfacePanel.tsx
+++ b/packages/ts/lights/src/components/SurfacePanel.tsx
@@ -193,6 +193,39 @@ export default function SurfacePanel() {
         </div>
       )}
 
+      <div className="surface-panel-header">
+        <span>Volume</span>
+        {selectedSlideId && !slide?.volume && (
+          <button
+            className="icon-btn"
+            title="Add volume"
+            onClick={() => dispatch({ type: 'volume:add', slideId: selectedSlideId })}
+          >
+            +
+          </button>
+        )}
+      </div>
+
+      {selectedSlideId && slide?.volume ? (
+        <div className="surface-list">
+          <div className="surface-item">
+            <span className="surface-name">{slide.volume.name}</span>
+            <button
+              className="icon-btn surface-remove"
+              title="Remove volume"
+              onClick={e => {
+                e.stopPropagation()
+                dispatch({ type: 'volume:remove', slideId: selectedSlideId })
+              }}
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      ) : selectedSlideId ? (
+        <p className="panel-empty">No volume</p>
+      ) : null}
+
       <GraphConfigPanel />
     </aside>
   )

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useReducer, useRef } from 'react'
 import type { Dispatch, ReactNode } from 'react'
-import type { ImageLayer, Layer, Project, Slide, Surface, TextLayer } from './types'
+import type { ImageLayer, Layer, Project, Slide, Surface, TextLayer, Volume } from './types'
 
 // ── State ────────────────────────────────────────────────────────────────────
 
@@ -52,6 +52,8 @@ export type ProjectAction =
   | { type: 'layer:select'; layerId: string | null }
   | { type: 'layer:toggle-visibility'; slideId: string; surfaceId: string; layerId: string }
   | { type: 'slide:updateGraphConfig'; slideId: string; config: import('../ipc/types').GraphConfig }
+  | { type: 'volume:add'; slideId: string }
+  | { type: 'volume:remove'; slideId: string }
 
 // ── Reducer ──────────────────────────────────────────────────────────────────
 
@@ -326,6 +328,35 @@ function projectMutationReducer(state: ProjectState, action: ProjectAction): Pro
         project: {
           ...project,
           slides: project.slides.map(s => s.id === action.slideId ? { ...s, graphConfig: action.config } : s),
+        },
+      }
+
+    case 'volume:add': {
+      const volume: Volume = {
+        id: crypto.randomUUID(),
+        name: 'Volume',
+        camera: {
+          position: { x: 0, y: 2, z: 5 },
+          target: { x: 0, y: 0, z: 0 },
+          fov: 50,
+        },
+        shapes: [],
+      }
+      return {
+        ...state,
+        project: {
+          ...project,
+          slides: project.slides.map(s => s.id === action.slideId ? { ...s, volume } : s),
+        },
+      }
+    }
+
+    case 'volume:remove':
+      return {
+        ...state,
+        project: {
+          ...project,
+          slides: project.slides.map(s => s.id === action.slideId ? { ...s, volume: undefined } : s),
         },
       }
 

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -23,7 +23,35 @@ export type Layer = SolidLayer | ImageLayer | TextLayer
 
 export interface Reaction { id: string }
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Calibration {} // populated by M5 (camera-to-projector mapping)
+export interface Calibration {} // populated by M6 (camera-to-projector mapping)
+
+export type VolumeShapeType = 'box' | 'sphere' | 'cylinder' | 'cone'
+
+export interface Vec3 { x: number; y: number; z: number }
+
+export interface VolumeCamera {
+  position: Vec3
+  target: Vec3
+  fov: number
+}
+
+export interface VolumeShape {
+  id: string
+  name: string
+  type: VolumeShapeType
+  position: Vec3
+  rotation: Vec3  // Euler XYZ degrees
+  scale: Vec3
+  layers: Layer[]
+  reactions: Reaction[]
+}
+
+export interface Volume {
+  id: string
+  name: string
+  camera: VolumeCamera
+  shapes: VolumeShape[]
+}
 
 export interface Surface {
   id: string
@@ -39,6 +67,7 @@ export interface Slide {
   name: string
   surfaces: Surface[]
   graphConfig: GraphConfig
+  volume?: Volume
 }
 
 export interface Project {

--- a/packages/ts/lights/volumes-guidelines.md
+++ b/packages/ts/lights/volumes-guidelines.md
@@ -1,0 +1,132 @@
+# Volumes Editor — Feature Guidelines
+
+## What is a Volume?
+
+A **Volume** is a 3D scene composited into the main stage canvas. It has its own virtual camera
+whose perspective you align with your real-world projection environment, so the 3D content appears
+to "sit" correctly in the physical space. Once the camera is aligned, you enter the Volume editor
+to populate the scene with 3D primitives.
+
+Think of it as: the Stage is 2D + flat Surfaces; a Volume punches a 3D viewport into that same
+canvas, perspective-matched to the projector.
+
+---
+
+## Workflow
+
+```
+Stage view
+  └── Add Volume
+        ↓
+      3D scene composited on canvas (empty at first)
+      [Align camera] → HUD with vanishing point overlay + arrow controls
+        ↓
+      Enter Volume editor
+        └── Add primitives (box, sphere, cylinder…)
+            Position / rotate / scale them in 3D space
+```
+
+Camera alignment happens **in the stage view** — you're watching the full projected output while
+nudging the virtual camera until it matches the physical environment. Only then do you go inside
+to build the scene.
+
+---
+
+## Data Model
+
+```ts
+export type VolumeShapeType = 'box' | 'sphere' | 'cylinder' | 'cone'
+
+export interface VolumeShape {
+  id: string
+  name: string
+  type: VolumeShapeType
+  position: { x: number; y: number; z: number }
+  rotation: { x: number; y: number; z: number }  // Euler XYZ degrees
+  scale: { x: number; y: number; z: number }
+  layers: Layer[]        // same types as Surface — texture mapped onto the shape
+  reactions: Reaction[]  // same types as Surface
+}
+
+export interface VolumeCamera {
+  position: { x: number; y: number; z: number }
+  target: { x: number; y: number; z: number }  // look-at point
+  fov: number  // degrees, default 50
+}
+
+export interface Volume {
+  id: string
+  name: string
+  camera: VolumeCamera
+  shapes: VolumeShape[]
+}
+```
+
+`Slide` gains a `volume?: Volume` field alongside `surfaces`. One Volume per slide — a single 3D
+scene for the whole projected output. World unit scale is arbitrary but consistent within a scene.
+
+`VolumeShape` deliberately mirrors `Surface`: same `Layer` and `Reaction` types, same mental model.
+This keeps the UI familiar and makes future factorization straightforward.
+
+---
+
+## Stage View — Camera Alignment
+
+Clicking **[Align camera]** on the Volume row in the side panel activates the alignment HUD over
+the stage canvas. The HUD renders a fixed **two-point perspective grid** (horizon line + two sets
+of converging lines) as a visual reference. You nudge the virtual camera until the grid lines
+match the perspective of the real-world environment visible in the projected output.
+
+Arrow controls (always one fixed increment per click):
+
+| Button | Effect |
+|--------|--------|
+| Orbit ←→ ↑↓ | Rotate camera around target point |
+| Pan ←→ ↑↓ | Translate camera + target laterally |
+| Dolly + − | Push camera toward / away from target |
+| FOV + − | Widen / narrow field of view |
+
+All changes to `Volume.camera` are live. **[Done]** exits the HUD and saves camera state.
+
+---
+
+## Volume Editor — 3D Scene
+
+Entering a Volume switches the canvas to a dedicated 3D editor. The editor camera is a free orbit
+camera (independent from the projection camera) so you can navigate freely while authoring. The
+projection camera is shown as a ghost frustum so you always know what the projector will see.
+
+Controls:
+- **Orbit / pan / zoom** — mouse drag / scroll (`OrbitControls`)
+- **Create Shape** — picker for box / sphere / cylinder / cone, inserted at origin
+- **Select + transform gizmo** — click to select, drag handles to translate / rotate / scale
+  (`TransformControls`)
+- **Delete** — removes selected shape
+- **View from projector** — snaps the editor camera to `Volume.camera` for a projection preview
+
+A ground grid and axis indicator help with orientation.
+
+---
+
+## Rendering / Compositing
+
+The Volume's 3D scene renders in the same Three.js canvas as the Stage, as a separate pass on top
+of the flat surface quads. The projection camera (`Volume.camera`) drives the perspective matrix
+for this pass. The free-orbit editor camera is only active inside the Volume editor.
+
+**Open question:** render order — does the 3D scene always render on top of flat surfaces, or
+should depth ordering be respected? Rendering on top is simpler; depth ordering requires a unified
+depth buffer across both passes.
+
+---
+
+## Out of scope
+
+- Custom mesh / OBJ / GLTF import
+- Per-face layer assignment
+- Spatial audio
+- Animation / keyframing
+- Camera calibration tie-in (M5)
+- Numeric transform input fields, snapping, grid alignment
+- Mouse-drag orbit on the stage overlay
+- User-draggable vanishing point lines


### PR DESCRIPTION
Closes #46

## Changes

- **`model/types.ts`** — adds `Vec3`, `VolumeCamera`, `VolumeShapeType`, `VolumeShape`, `Volume` types; updates `Slide` with `volume?: Volume`
- **`model/ProjectContext.tsx`** — adds `volume:add` and `volume:remove` actions + reducer cases
- **`components/SurfacePanel.tsx`** — adds a Volumes section to the Stage mode right panel

## Behaviour

- Stage mode right panel shows a **Volume** section below the surfaces list
- `[+]` button creates a Volume with a sensible default camera (`position {0,2,5}`, `target {0,0,0}`, `fov 50`) and empty shapes
- Volume row shows the volume name and a `×` delete button (visible on hover, consistent with surface rows)
- `volume` round-trips through project save/load with no extra work — it's plain JSON on `Slide`
- Slides without a volume are unaffected

## Test plan

- [ ] Add a Volume to a slide — row appears, `[+]` disappears
- [ ] Delete the Volume — row gone, `[+]` reappears
- [ ] Save project with a Volume, reopen — Volume persists
- [ ] Slides without a Volume show "No volume" placeholder
- [ ] Existing surface behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)