### PR TITLE
feat(volumes): 3D scene rendering — composite Volume onto stage canvas

### DIFF
--- a/packages/ts/lights/src/components/Canvas.tsx
+++ b/packages/ts/lights/src/components/Canvas.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { useProject } from '../model/ProjectContext';
-import { buildSurfaceMesh, disposeSurfaceMesh } from '../shaders/homography';
+import { buildSurfaceMesh, disposeSurfaceMesh, preloadSurfaces } from '../shaders/homography';
+import { buildShapeMesh, disposeShapeMesh } from '../shaders/volumeScene';
 import type { Hand, Landmark } from './canvas/landmarks';
 import {
   decodeFacemesh,
@@ -10,7 +11,6 @@ import {
   drawHands,
   frameRect,
 } from './canvas/landmarks';
-import { preloadSurfaces } from '../shaders/homography';
 
 /**
  * Main stage canvas: renders the live camera frame as a WebGL texture, overlays
@@ -21,6 +21,8 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const renderRef = useRef<() => void>(() => {});
   const surfaceGroupRef = useRef<THREE.Group | null>(null);
+  const volumeGroupRef = useRef<THREE.Group | null>(null);
+  const volumeCameraRef = useRef<THREE.PerspectiveCamera | null>(null);
 
   const showVideoRef = useRef(showVideo);
   showVideoRef.current = showVideo;
@@ -30,6 +32,11 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
 
   const surfaces = useMemo(
     () => project.slides.find((s) => s.id === selectedSlideId)?.surfaces ?? [],
+    [project.slides, selectedSlideId],
+  );
+
+  const volume = useMemo(
+    () => project.slides.find((s) => s.id === selectedSlideId)?.volume,
     [project.slides, selectedSlideId],
   );
 
@@ -65,9 +72,27 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
     scene.add(surfaceGroup);
     surfaceGroupRef.current = surfaceGroup;
 
+    const volumeScene = new THREE.Scene();
+    const volumeCamera = new THREE.PerspectiveCamera(
+      50,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      1000,
+    );
+    volumeCamera.position.set(0, 2, 5);
+    volumeCamera.lookAt(0, 0, 0);
+    volumeCameraRef.current = volumeCamera;
+
+    const volumeGroup = new THREE.Group();
+    volumeScene.add(volumeGroup);
+    volumeGroupRef.current = volumeGroup;
+
     const render = () => {
       mesh.visible = showVideoRef.current;
+      renderer.autoClear = true;
       renderer.render(scene, camera);
+      renderer.autoClear = false;
+      renderer.render(volumeScene, volumeCamera);
     };
     renderRef.current = render;
 
@@ -88,6 +113,8 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
       renderer.setSize(w, h);
       overlay.width = w;
       overlay.height = h;
+      volumeCamera.aspect = w / h;
+      volumeCamera.updateProjectionMatrix();
       render();
     }
 
@@ -172,6 +199,27 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
 
   // Re-render when showVideo toggles so the mesh visibility updates immediately.
   useEffect(() => { renderRef.current(); }, [showVideo]);
+
+  // ── Volume scene (rebuilt whenever the active slide's volume changes) ──────
+  useEffect(() => {
+    const group = volumeGroupRef.current;
+    const cam = volumeCameraRef.current;
+    if (!group || !cam) return;
+
+    group.traverse(child => { if (child instanceof THREE.Mesh) disposeShapeMesh(child as THREE.Mesh) });
+    group.clear();
+
+    if (volume) {
+      const { position: p, target: t, fov } = volume.camera;
+      cam.position.set(p.x, p.y, p.z);
+      cam.lookAt(new THREE.Vector3(t.x, t.y, t.z));
+      cam.fov = fov;
+      cam.updateProjectionMatrix();
+      for (const shape of volume.shapes) group.add(buildShapeMesh(shape));
+    }
+
+    renderRef.current();
+  }, [volume]);
 
   // ── Surface meshes (rebuilt whenever the active slide's surfaces change) ──
   useEffect(() => {

--- a/packages/ts/lights/src/shaders/volumeScene.ts
+++ b/packages/ts/lights/src/shaders/volumeScene.ts
@@ -1,0 +1,27 @@
+import * as THREE from 'three'
+import type { VolumeShape } from '../model/types'
+
+export function buildShapeMesh(shape: VolumeShape): THREE.Mesh {
+  let geo: THREE.BufferGeometry
+  switch (shape.type) {
+    case 'box':      geo = new THREE.BoxGeometry(); break
+    case 'sphere':   geo = new THREE.SphereGeometry(0.5, 32, 16); break
+    case 'cylinder': geo = new THREE.CylinderGeometry(0.5, 0.5, 1, 32); break
+    case 'cone':     geo = new THREE.ConeGeometry(0.5, 1, 32); break
+  }
+  const mat = new THREE.MeshNormalMaterial()
+  const mesh = new THREE.Mesh(geo, mat)
+  mesh.position.set(shape.position.x, shape.position.y, shape.position.z)
+  mesh.rotation.set(
+    shape.rotation.x * Math.PI / 180,
+    shape.rotation.y * Math.PI / 180,
+    shape.rotation.z * Math.PI / 180,
+  )
+  mesh.scale.set(shape.scale.x, shape.scale.y, shape.scale.z)
+  return mesh
+}
+
+export function disposeShapeMesh(mesh: THREE.Mesh): void {
+  mesh.geometry.dispose()
+  ;(mesh.material as THREE.Material).dispose()
+}


### PR DESCRIPTION
Closes #47

## Changes

- **`shaders/volumeScene.ts`** (new) — `buildShapeMesh` and `disposeShapeMesh` for the four primitive types (box / sphere / cylinder / cone). Uses `MeshNormalMaterial` as placeholder; layers come in #50.
- **`components/Canvas.tsx`** — second render pass using `autoClear = false`:
  - `volumeScene` + `volumeCamera` (PerspectiveCamera) created alongside the existing orthographic scene
  - `render()` runs the flat-surface pass first, then composites the volume scene on top
  - `updateLayout` keeps `volumeCamera.aspect` in sync with canvas resize
  - New reactive effect rebuilds shape meshes and syncs camera params whenever `slide.volume` changes

## How it works

```
render()
  autoClear = true  → renderer.render(scene, orthoCamera)   // video + surfaces
  autoClear = false → renderer.render(volumeScene, perspCamera) // 3D shapes on top
```

Volume shapes render on top of flat surfaces. Depth ordering between the two passes is deferred until a real use-case requires it.

## Test plan

- [ ] Add a Volume to a slide, then enter the Volume editor (next issue) and add a box — it renders on stage
- [ ] `Volume.camera` position/target/fov is reflected in the projected perspective
- [ ] Canvas resize keeps volume camera aspect correct (no stretch/squash)
- [ ] Slides without a Volume are unaffected — no regression on surface rendering
- [ ] Switching slides clears the previous slide's volume shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)