### PR TITLE
feat(reactions): data model — Reaction types + ShaderLayer

### DIFF
--- a/lib/three-scene/src/types.ts
+++ b/lib/three-scene/src/types.ts
@@ -41,7 +41,11 @@ export interface LayerTransform {
 export interface SolidLayer { id: string; type: 'solid'; name: string; visible: boolean; color: string; transform: LayerTransform }
 export interface ImageLayer { id: string; type: 'image'; name: string; visible: boolean; src: string; transform: LayerTransform }
 export interface TextLayer { id: string; type: 'text'; name: string; visible: boolean; content: string; fontSize: number; color: string; transform: LayerTransform }
-export type Layer = SolidLayer | ImageLayer | TextLayer
+
+export type ShaderPreset = 'pulse' | 'ripple' | 'chromatic'
+export interface ShaderLayer { id: string; type: 'shader'; name: string; visible: boolean; preset: ShaderPreset; uniforms: Record<string, number>; transform: LayerTransform }
+
+export type Layer = SolidLayer | ImageLayer | TextLayer | ShaderLayer
 
 export interface Surface {
   id: string

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -1,12 +1,13 @@
 import type { Point as BasePoint, GraphConfig } from '../ipc/types'
-import type { 
-  VolumeShapeType, VolumeEditMode, Vec3, VolumeCamera, 
+import type {
+  VolumeShapeType, VolumeEditMode, Vec3, VolumeCamera,
   VolumeShape as BaseVolumeShape, Volume as BaseVolume,
   SolidLayer as BaseSolidLayer, ImageLayer as BaseImageLayer, TextLayer as BaseTextLayer,
+  ShaderLayer as BaseShaderLayer, ShaderPreset,
   LayerTransform as BaseLayerTransform, Point, Surface as BaseSurface
 } from '@lights/three-scene'
 
-export type { GraphConfig, VolumeShapeType, VolumeEditMode, Vec3, VolumeCamera, Point }
+export type { GraphConfig, VolumeShapeType, VolumeEditMode, Vec3, VolumeCamera, Point, ShaderPreset }
 
 export type Polygon = BasePoint[]
 
@@ -17,9 +18,25 @@ export interface LayerTransform extends BaseLayerTransform {
 export interface SolidLayer extends BaseSolidLayer { transform: LayerTransform }
 export interface ImageLayer extends BaseImageLayer { transform: LayerTransform }
 export interface TextLayer extends BaseTextLayer { transform: LayerTransform }
-export type Layer = SolidLayer | ImageLayer | TextLayer
+export interface ShaderLayer extends BaseShaderLayer { transform: LayerTransform }
+export type Layer = SolidLayer | ImageLayer | TextLayer | ShaderLayer
 
-export interface Reaction { id: string }
+// ── Reactions ─────────────────────────────────────────────────────────────────
+
+export type ReactionTrigger =
+  | { kind: 'detection'; moduleId: string }
+
+export type ReactionAction =
+  | { kind: 'shader:setUniform'; layerId: string; uniform: string; value: number }
+  | { kind: 'layer:opacity'; layerId: string; value: number }
+
+export interface Reaction {
+  id: string
+  name: string
+  trigger: ReactionTrigger
+  action: ReactionAction
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface Calibration {} // populated by M6 (camera-to-projector mapping)
 


### PR DESCRIPTION
Closes #59

## What

Expands the reaction and layer type stubs into real typed interfaces, setting up everything downstream issues will build on.

### `lib/three-scene/src/types.ts`

- Added `ShaderPreset = 'pulse' | 'ripple' | 'chromatic'`
- Added `ShaderLayer` interface with `preset`, `uniforms`, and `transform`
- Updated `Layer` union to include `ShaderLayer`

### `packages/ts/lights/src/model/types.ts`

- Re-exports `ShaderPreset` from `@lights/three-scene`
- Adds app-level `ShaderLayer` (extends base with app `LayerTransform`)
- Updates app `Layer` union
- Replaces `Reaction { id: string }` stub with:
  - `ReactionTrigger` — `{ kind: 'detection'; moduleId: string }`
  - `ReactionAction` — `shader:setUniform` | `layer:opacity`
  - Full `Reaction { id, name, trigger, action }`

## Notes

- No runtime changes — this is types only
- `homography.ts`, `LayerObject`, `LayerList`, and `ProjectContext` all handle the new type gracefully without changes (non-exhaustive checks, empty array initialisers, catch-all else branches)
- Existing saved projects are unaffected — `reactions` arrays are always `[]` in practice

## Test plan

- [x] `yarn nx run @lights/app:build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)