### PR TITLE
feat(shader): render ShaderLayer on surface

### DIFF
--- a/lib/three-scene/src/homography.ts
+++ b/lib/three-scene/src/homography.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import type { ImageLayer, SolidLayer, Surface, TextLayer, Layer, Point } from './types'
+import type { ImageLayer, ShaderLayer, ShaderPreset, SolidLayer, Surface, TextLayer, Layer, Point } from './types'
 
 // ── Shaders ──────────────────────────────────────────────────────────────────
 
@@ -33,6 +33,56 @@ void main() {
   gl_FragColor = texture2D(uTexture, vec2(vUv.x, 1.0 - vUv.y));
 }
 `
+
+// ── ShaderLayer presets ───────────────────────────────────────────────────────
+
+const fragmentShaderPulse = /* glsl */`
+varying vec2 vUv;
+uniform float uTime;
+uniform float uIntensity;
+void main() {
+  float wave = 0.5 + 0.5 * sin(uTime * 1.4 + vUv.x * 2.5 + vUv.y * 1.8);
+  vec3 col = vec3(0.2 + wave * 0.3, 0.3 + wave * 0.2, 0.85 + wave * 0.15);
+  float alpha = 0.3 + wave * 0.35 + uIntensity * 0.45;
+  gl_FragColor = vec4(col, min(1.0, alpha));
+}
+`
+
+const fragmentShaderRipple = /* glsl */`
+varying vec2 vUv;
+uniform float uTime;
+uniform float uIntensity;
+void main() {
+  float dist = length(vUv - vec2(0.5));
+  float speed = 1.5 + uIntensity * 5.0;
+  float ring = 0.5 + 0.5 * sin(dist * 16.0 - uTime * speed);
+  float fade = max(0.0, 1.0 - dist * 2.0);
+  float alpha = ring * fade * (0.25 + uIntensity * 0.6);
+  vec3 col = mix(vec3(0.15, 0.55, 1.0), vec3(1.0, 0.8, 0.15), uIntensity);
+  gl_FragColor = vec4(col, alpha);
+}
+`
+
+const fragmentShaderChromatic = /* glsl */`
+varying vec2 vUv;
+uniform float uTime;
+uniform float uIntensity;
+void main() {
+  vec2 c = vUv - 0.5;
+  float s = 0.012 + uIntensity * 0.06;
+  float r = 0.5 + 0.5 * sin(length(c + c * s) * 9.0 - uTime * 0.9);
+  float g = 0.5 + 0.5 * sin(length(c) * 9.0 - uTime * 0.9 + 2.094);
+  float b = 0.5 + 0.5 * sin(length(c - c * s) * 9.0 - uTime * 0.9 + 4.189);
+  float alpha = 0.45 + uIntensity * 0.35;
+  gl_FragColor = vec4(r, g, b, alpha);
+}
+`
+
+const PRESET_SHADERS: Record<ShaderPreset, string> = {
+  pulse:     fragmentShaderPulse,
+  ripple:    fragmentShaderRipple,
+  chromatic: fragmentShaderChromatic,
+}
 
 // ── Math ─────────────────────────────────────────────────────────────────────
 
@@ -106,12 +156,13 @@ export async function preloadSurfaces(surfaces: Surface[]): Promise<void> {
 
 // ── Texture compositor ────────────────────────────────────────────────────────
 
-// Composite all visible layers onto an offscreen canvas (surface local space,
-// Y-down), then wrap it in a Three.js CanvasTexture. Returns null if no layers.
+// Composite all visible non-shader layers onto an offscreen canvas (surface
+// local space, Y-down), then wrap it in a Three.js CanvasTexture. Returns null
+// if no renderable layers remain.
 const TEX_SIZE = 512
 
 function buildSurfaceTexture(surface: Surface): THREE.CanvasTexture | null {
-  const visibleLayers = surface.layers.filter((l: Layer) => l.visible)
+  const visibleLayers = surface.layers.filter((l: Layer) => l.visible && l.type !== 'shader')
   if (visibleLayers.length === 0) return null
 
   const canvas = document.createElement('canvas')
@@ -122,7 +173,7 @@ function buildSurfaceTexture(surface: Surface): THREE.CanvasTexture | null {
   // Render bottom-to-top: surface.layers[0] is the top layer in the panel,
   // so we iterate in reverse to draw the backmost layer first.
   for (const layer of [...surface.layers].reverse()) {
-    if (!layer.visible) continue
+    if (!layer.visible || layer.type === 'shader') continue
 
     const t = layer.transform
     ctx.save()
@@ -161,10 +212,41 @@ function buildSurfaceTexture(surface: Surface): THREE.CanvasTexture | null {
   return new THREE.CanvasTexture(canvas)
 }
 
-// ── Mesh builder ─────────────────────────────────────────────────────────────
+// ── Geometry builder ──────────────────────────────────────────────────────────
 
 // UV corners matching outputPolygon corner order: TL, TR, BR, BL
 const SRC_UVS: [number, number][] = [[0, 0], [1, 0], [1, 1], [0, 1]]
+
+// Builds the homography-warped BufferGeometry for a surface. Shared by both
+// the canvas-texture mesh and per-ShaderLayer meshes.
+function buildHomographyGeo(surface: Surface): THREE.BufferGeometry {
+  // Convert normalized stage [0,1] coords to NDC [-1,1]; flip Y (stage Y↓, NDC Y↑)
+  const dst: [number, number][] = surface.outputPolygon.map((p: Point) => [
+    p.x * 2 - 1,
+    1 - p.y * 2,
+  ])
+  const H = computeHomography(SRC_UVS, dst)
+  const positions = new Float32Array(12)
+  const uvs       = new Float32Array(8)
+  const ws        = new Float32Array(4)
+  SRC_UVS.forEach(([u, v], i) => {
+    const w = H[6] * u + H[7] * v + H[8]
+    positions[i * 3]     = dst[i][0] * w
+    positions[i * 3 + 1] = dst[i][1] * w
+    positions[i * 3 + 2] = 0
+    uvs[i * 2]     = u
+    uvs[i * 2 + 1] = v
+    ws[i]          = w
+  })
+  const geo = new THREE.BufferGeometry()
+  geo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  geo.setAttribute('uv',       new THREE.BufferAttribute(uvs, 2))
+  geo.setAttribute('aW',       new THREE.BufferAttribute(ws, 1))
+  geo.setIndex([0, 1, 2, 0, 2, 3])
+  return geo
+}
+
+// ── Mesh builders ─────────────────────────────────────────────────────────────
 
 const COLORS: [number, number, number][] = [
   [0.38, 0.65, 0.98],
@@ -175,34 +257,7 @@ const COLORS: [number, number, number][] = [
 ]
 
 export function buildSurfaceMesh(surface: Surface, colorIdx: number): THREE.Mesh {
-  // Convert normalized stage [0,1] coords to NDC [-1,1]; flip Y (stage Y↓, NDC Y↑)
-  const dst: [number, number][] = surface.outputPolygon.map((p: Point) => [
-    p.x * 2 - 1,
-    1 - p.y * 2,
-  ])
-
-  const H = computeHomography(SRC_UVS, dst)
-
-  const positions = new Float32Array(12)
-  const uvs = new Float32Array(8)
-  const ws = new Float32Array(4)
-
-  SRC_UVS.forEach(([u, v], i) => {
-    const w = H[6] * u + H[7] * v + H[8]
-    positions[i * 3]     = dst[i][0] * w
-    positions[i * 3 + 1] = dst[i][1] * w
-    positions[i * 3 + 2] = 0
-    uvs[i * 2]     = u
-    uvs[i * 2 + 1] = v
-    ws[i] = w
-  })
-
-  const geo = new THREE.BufferGeometry()
-  geo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
-  geo.setAttribute('uv',       new THREE.BufferAttribute(uvs, 2))
-  geo.setAttribute('aW',       new THREE.BufferAttribute(ws, 1))
-  geo.setIndex([0, 1, 2, 0, 2, 3])
-
+  const geo     = buildHomographyGeo(surface)
   const texture = buildSurfaceTexture(surface)
   const material = texture
     ? new THREE.ShaderMaterial({
@@ -221,8 +276,34 @@ export function buildSurfaceMesh(surface: Surface, colorIdx: number): THREE.Mesh
         side: THREE.DoubleSide,
         depthTest: false,
       })
-
   return new THREE.Mesh(geo, material)
+}
+
+/** One mesh per visible ShaderLayer on the surface, rendered on top of the
+ *  canvas-texture pass. Each mesh stores `layerId` in `userData` so the
+ *  reaction engine can target uniforms by layer id. */
+export function buildShaderLayerMeshes(surface: Surface): THREE.Mesh[] {
+  const meshes: THREE.Mesh[] = []
+  for (const layer of surface.layers) {
+    if (layer.type !== 'shader' || !layer.visible) continue
+    const sl = layer as ShaderLayer
+    const geo = buildHomographyGeo(surface)
+    const material = new THREE.ShaderMaterial({
+      vertexShader,
+      fragmentShader: PRESET_SHADERS[sl.preset],
+      uniforms: {
+        uTime:      { value: 0 },
+        uIntensity: { value: sl.uniforms.uIntensity ?? 0 },
+      },
+      transparent: true,
+      side: THREE.DoubleSide,
+      depthTest: false,
+    })
+    const mesh = new THREE.Mesh(geo, material)
+    mesh.userData.layerId = sl.id
+    meshes.push(mesh)
+  }
+  return meshes
 }
 
 export function disposeSurfaceMesh(mesh: THREE.Mesh): void {
@@ -230,4 +311,9 @@ export function disposeSurfaceMesh(mesh: THREE.Mesh): void {
   const mat = mesh.material as THREE.ShaderMaterial
   ;(mat.uniforms.uTexture?.value as THREE.Texture | undefined)?.dispose()
   mat.dispose()
+}
+
+export function disposeShaderLayerMesh(mesh: THREE.Mesh): void {
+  mesh.geometry.dispose()
+  ;(mesh.material as THREE.ShaderMaterial).dispose()
 }

--- a/lib/three-scene/src/types.ts
+++ b/lib/three-scene/src/types.ts
@@ -41,7 +41,11 @@ export interface LayerTransform {
 export interface SolidLayer { id: string; type: 'solid'; name: string; visible: boolean; color: string; transform: LayerTransform }
 export interface ImageLayer { id: string; type: 'image'; name: string; visible: boolean; src: string; transform: LayerTransform }
 export interface TextLayer { id: string; type: 'text'; name: string; visible: boolean; content: string; fontSize: number; color: string; transform: LayerTransform }
-export type Layer = SolidLayer | ImageLayer | TextLayer
+
+export type ShaderPreset = 'pulse' | 'ripple' | 'chromatic'
+export interface ShaderLayer { id: string; type: 'shader'; name: string; visible: boolean; preset: ShaderPreset; uniforms: Record<string, number>; transform: LayerTransform }
+
+export type Layer = SolidLayer | ImageLayer | TextLayer | ShaderLayer
 
 export interface Surface {
   id: string

--- a/packages/ts/lights/src/OutputApp.tsx
+++ b/packages/ts/lights/src/OutputApp.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import type { Slide } from './model/types';
-import { buildSurfaceMesh, disposeSurfaceMesh, preloadSurfaces, buildShapeMesh, disposeShapeMesh } from '@lights/three-scene';
+import { buildSurfaceMesh, disposeSurfaceMesh, preloadSurfaces, buildShapeMesh, disposeShapeMesh, buildShaderLayerMeshes, disposeShaderLayerMesh } from '@lights/three-scene';
 
 export default function OutputApp() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -19,6 +19,22 @@ export default function OutputApp() {
     const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
     const surfaceGroup = new THREE.Group();
     scene.add(surfaceGroup);
+    const shaderGroup = new THREE.Group();
+    scene.add(shaderGroup);
+
+    // rAF loop for ShaderLayer uTime animation
+    let animId: number | null = null;
+    const t0 = performance.now();
+    function tick() {
+      const t = (performance.now() - t0) / 1000;
+      shaderGroup.traverse(obj => {
+        if (!(obj instanceof THREE.Mesh)) return;
+        const mat = obj.material as THREE.ShaderMaterial;
+        if (mat.uniforms?.uTime) mat.uniforms.uTime.value = t;
+      });
+      render();
+      animId = requestAnimationFrame(tick);
+    }
 
     // ── Volume pass (perspective) ─────────────────────────────────────────────
     const volumeScene = new THREE.Scene();
@@ -35,17 +51,19 @@ export default function OutputApp() {
 
     async function renderSlide(slide: Slide) {
       // Surfaces
-      surfaceGroup.traverse((child) => {
-        if (child instanceof THREE.Mesh) disposeSurfaceMesh(child);
-      });
+      surfaceGroup.traverse((child) => { if (child instanceof THREE.Mesh) disposeSurfaceMesh(child); });
       surfaceGroup.clear();
+      shaderGroup.traverse((obj) => { if (obj instanceof THREE.Mesh) disposeShaderLayerMesh(obj); });
+      shaderGroup.clear();
+
       await preloadSurfaces(slide.surfaces);
       slide.surfaces.forEach((surface, i) => surfaceGroup.add(buildSurfaceMesh(surface, i)));
+      for (const surface of slide.surfaces) {
+        for (const mesh of buildShaderLayerMeshes(surface)) shaderGroup.add(mesh);
+      }
 
       // Volume
-      volumeGroup.traverse((child) => {
-        if (child instanceof THREE.Mesh) disposeShapeMesh(child as THREE.Mesh);
-      });
+      volumeGroup.traverse((child) => { if (child instanceof THREE.Mesh) disposeShapeMesh(child as THREE.Mesh); });
       volumeGroup.clear();
 
       if (slide.volume) {
@@ -57,7 +75,10 @@ export default function OutputApp() {
         for (const shape of slide.volume.shapes) volumeGroup.add(buildShapeMesh(shape));
       }
 
-      render();
+      const hasShaders = slide.surfaces.some(s => s.layers.some(l => l.type === 'shader' && l.visible));
+      if (hasShaders && animId === null) animId = requestAnimationFrame(tick);
+      else if (!hasShaders && animId !== null) { cancelAnimationFrame(animId); animId = null; render(); }
+      else if (!hasShaders) render();
     }
 
     const off = window.lights.onOutputRender((data) => {
@@ -77,14 +98,12 @@ export default function OutputApp() {
     updateLayout();
 
     return () => {
+      if (animId !== null) cancelAnimationFrame(animId);
       off();
       observer.disconnect();
-      surfaceGroup.traverse((child) => {
-        if (child instanceof THREE.Mesh) disposeSurfaceMesh(child);
-      });
-      volumeGroup.traverse((child) => {
-        if (child instanceof THREE.Mesh) disposeShapeMesh(child as THREE.Mesh);
-      });
+      surfaceGroup.traverse((child) => { if (child instanceof THREE.Mesh) disposeSurfaceMesh(child); });
+      shaderGroup.traverse((obj) => { if (obj instanceof THREE.Mesh) disposeShaderLayerMesh(obj); });
+      volumeGroup.traverse((child) => { if (child instanceof THREE.Mesh) disposeShapeMesh(child as THREE.Mesh); });
       renderer.dispose();
       container.removeChild(renderer.domElement);
     };

--- a/packages/ts/lights/src/components/Canvas.tsx
+++ b/packages/ts/lights/src/components/Canvas.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { useProject } from '../model/ProjectContext';
-import { buildSurfaceMesh, disposeSurfaceMesh, preloadSurfaces, buildShapeMesh, disposeShapeMesh } from '@lights/three-scene';
+import { buildSurfaceMesh, disposeSurfaceMesh, preloadSurfaces, buildShapeMesh, disposeShapeMesh, buildShaderLayerMeshes, disposeShaderLayerMesh } from '@lights/three-scene';
 import type { Hand, Landmark } from './canvas/landmarks';
 import {
   decodeFacemesh,
@@ -20,8 +20,11 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const renderRef = useRef<() => void>(() => {});
   const surfaceGroupRef = useRef<THREE.Group | null>(null);
-  const volumeGroupRef = useRef<THREE.Group | null>(null);
+  const shaderGroupRef  = useRef<THREE.Group | null>(null);
+  const volumeGroupRef  = useRef<THREE.Group | null>(null);
   const volumeCameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const startAnimRef    = useRef<() => void>(() => {});
+  const stopAnimRef     = useRef<() => void>(() => {});
 
   const showVideoRef = useRef(showVideo);
   showVideoRef.current = showVideo;
@@ -70,6 +73,26 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
     const surfaceGroup = new THREE.Group();
     scene.add(surfaceGroup);
     surfaceGroupRef.current = surfaceGroup;
+
+    const shaderGroup = new THREE.Group();
+    scene.add(shaderGroup);
+    shaderGroupRef.current = shaderGroup;
+
+    // rAF loop — runs only while shader layers are present on the active slide
+    let animId: number | null = null;
+    const t0 = performance.now();
+    function tick() {
+      const t = (performance.now() - t0) / 1000;
+      shaderGroup.traverse(obj => {
+        if (!(obj instanceof THREE.Mesh)) return;
+        const mat = obj.material as THREE.ShaderMaterial;
+        if (mat.uniforms?.uTime) mat.uniforms.uTime.value = t;
+      });
+      render();
+      animId = requestAnimationFrame(tick);
+    }
+    startAnimRef.current = () => { if (animId === null) animId = requestAnimationFrame(tick); };
+    stopAnimRef.current  = () => { if (animId !== null) { cancelAnimationFrame(animId); animId = null; } };
 
     const volumeScene = new THREE.Scene();
     const volumeCamera = new THREE.PerspectiveCamera(
@@ -184,6 +207,7 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
     observer.observe(container);
 
     return () => {
+      stopAnimRef.current();
       off();
       observer.disconnect();
       if (handsExpiry) clearTimeout(handsExpiry);
@@ -223,22 +247,34 @@ export default function Canvas({ showVideo }: { showVideo: boolean }) {
 
   // ── Surface meshes (rebuilt whenever the active slide's surfaces change) ──
   useEffect(() => {
-    const group = surfaceGroupRef.current;
-    if (!group) return;
+    const group       = surfaceGroupRef.current;
+    const shaderGroup = shaderGroupRef.current;
+    if (!group || !shaderGroup) return;
 
     let cancelled = false;
+
+    // Clear shader meshes immediately so stale ones don't linger during preload
+    shaderGroup.traverse(obj => { if (obj instanceof THREE.Mesh) disposeShaderLayerMesh(obj); });
+    shaderGroup.clear();
+
     preloadSurfaces(surfaces).then(() => {
       if (cancelled) return;
       surfaces.forEach((surface, i) => group.add(buildSurfaceMesh(surface, i)));
-      renderRef.current();
+      for (const surface of surfaces) {
+        for (const mesh of buildShaderLayerMeshes(surface)) shaderGroup.add(mesh);
+      }
+      const hasShaders = surfaces.some(s => s.layers.some(l => l.type === 'shader' && l.visible));
+      if (hasShaders) startAnimRef.current();
+      else { stopAnimRef.current(); renderRef.current(); }
     });
 
     return () => {
       cancelled = true;
-      group.traverse((child) => {
-        if (child instanceof THREE.Mesh) disposeSurfaceMesh(child);
-      });
+      group.traverse((child) => { if (child instanceof THREE.Mesh) disposeSurfaceMesh(child); });
       group.clear();
+      shaderGroup.traverse(obj => { if (obj instanceof THREE.Mesh) disposeShaderLayerMesh(obj); });
+      shaderGroup.clear();
+      stopAnimRef.current();
     };
   }, [surfaces]);
 

--- a/packages/ts/lights/src/components/LayerList.tsx
+++ b/packages/ts/lights/src/components/LayerList.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { ImageLayer, Layer, SolidLayer, TextLayer } from '../model/types'
+import type { ImageLayer, Layer, ShaderLayer, SolidLayer, TextLayer } from '../model/types'
 
 interface LayerListProps {
   surface: { layers: Layer[] }
@@ -90,6 +90,9 @@ export default function LayerList({
               )}
               {layer.type === 'text' && (
                 <span className="layer-text-badge" style={{ color: (layer as TextLayer).color }}>T</span>
+              )}
+              {layer.type === 'shader' && (
+                <span className="layer-text-badge" style={{ color: '#7c6af7' }}>{(layer as ShaderLayer).preset[0].toUpperCase()}</span>
               )}
               <button
                 className="icon-btn layer-remove"

--- a/packages/ts/lights/src/components/LayerObject.tsx
+++ b/packages/ts/lights/src/components/LayerObject.tsx
@@ -1,4 +1,4 @@
-import type { ImageLayer, Layer, SolidLayer, TextLayer } from '../model/types'
+import type { ImageLayer, Layer, ShaderLayer, SolidLayer, TextLayer } from '../model/types'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -38,8 +38,15 @@ export default function LayerObject({
 }: LayerObjectProps) {
   const t = layer.transform
 
-  const bgStyle: React.CSSProperties =
-    layer.type === 'solid'
+  const shaderLayer = layer.type === 'shader' ? (layer as ShaderLayer) : null
+
+  const bgStyle: React.CSSProperties = shaderLayer
+    ? {
+        background: 'repeating-linear-gradient(45deg, rgba(124,106,247,0.08) 0px, rgba(124,106,247,0.08) 8px, transparent 8px, transparent 16px)',
+        border: '1.5px dashed rgba(124,106,247,0.5)',
+        boxSizing: 'border-box',
+      }
+    : layer.type === 'solid'
       ? { background: (layer as SolidLayer).color }
       : layer.type === 'image'
         ? {
@@ -70,6 +77,11 @@ export default function LayerObject({
           style={{ color: textLayer.color, fontSize: `${textLayer.fontSize * canvasH / 500}px` }}
         >
           {textLayer.content}
+        </div>
+      )}
+      {shaderLayer && (
+        <div className="layer-text-content" style={{ color: 'rgba(124,106,247,0.7)', fontSize: 11, pointerEvents: 'none' }}>
+          ⚡ {shaderLayer.preset}
         </div>
       )}
       {isSelected && (

--- a/packages/ts/lights/src/components/LayerToolbar.tsx
+++ b/packages/ts/lights/src/components/LayerToolbar.tsx
@@ -1,5 +1,5 @@
 import { useProject } from '../model'
-import { Square, Image as ImageIcon, Type } from 'lucide-react'
+import { Square, Image as ImageIcon, Type, Zap } from 'lucide-react'
 
 export default function LayerToolbar() {
   const { state, dispatch } = useProject()
@@ -21,6 +21,10 @@ export default function LayerToolbar() {
     dispatch({ type: 'layer:add-text', slideId: selectedSlideId!, surfaceId: selectedSurfaceId! })
   }
 
+  function addShader() {
+    dispatch({ type: 'layer:add-shader', slideId: selectedSlideId!, surfaceId: selectedSurfaceId! })
+  }
+
   return (
     <aside className="layer-toolbar">
       <button className="layer-tool-btn" title="Add solid layer" onClick={addSolid}>
@@ -31,6 +35,9 @@ export default function LayerToolbar() {
       </button>
       <button className="layer-tool-btn" title="Add text layer" onClick={addText}>
         <Type size={20} />
+      </button>
+      <button className="layer-tool-btn" title="Add shader layer" onClick={addShader}>
+        <Zap size={20} />
       </button>
     </aside>
   )

--- a/packages/ts/lights/src/components/SurfacePanel.tsx
+++ b/packages/ts/lights/src/components/SurfacePanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useProject } from '../model/ProjectContext'
-import type { SolidLayer, TextLayer, VolumeShapeType } from '../model/types'
+import type { ShaderLayer, ShaderPreset, SolidLayer, TextLayer, VolumeShapeType } from '../model/types'
 import LayerList from './LayerList'
 import GraphConfigPanel from './GraphConfigPanel'
 
@@ -38,8 +38,9 @@ export default function SurfacePanel() {
   // ── Surface mode: layer panel ─────────────────────────────────────────────
   if (editorMode === 'surface' && surface && selectedSlideId) {
     const selectedLayer = surface.layers.find(l => l.id === selectedLayerId)
-    const solidLayer = selectedLayer?.type === 'solid' ? (selectedLayer as SolidLayer) : undefined
-    const textLayer = selectedLayer?.type === 'text' ? (selectedLayer as TextLayer) : undefined
+    const solidLayer  = selectedLayer?.type === 'solid'  ? (selectedLayer as SolidLayer)  : undefined
+    const textLayer   = selectedLayer?.type === 'text'   ? (selectedLayer as TextLayer)   : undefined
+    const shaderLayer = selectedLayer?.type === 'shader' ? (selectedLayer as ShaderLayer) : undefined
 
     function removeLayer(layerId: string) {
       dispatch({ type: 'layer:remove', slideId: selectedSlideId!, surfaceId: surface!.id, layerId })
@@ -93,6 +94,20 @@ export default function SurfacePanel() {
               value={solidLayer.color}
               onChange={e => dispatch({ type: 'layer:update', slideId: selectedSlideId!, surfaceId: surface!.id, layer: { ...solidLayer, color: e.target.value } })}
             />
+          </div>
+        )}
+
+        {shaderLayer && (
+          <div className="surface-editor">
+            <label className="surface-editor-label">Preset</label>
+            <select
+              value={shaderLayer.preset}
+              onChange={e => dispatch({ type: 'layer:update', slideId: selectedSlideId!, surfaceId: surface!.id, layer: { ...shaderLayer, preset: e.target.value as ShaderPreset } })}
+            >
+              <option value="pulse">Pulse</option>
+              <option value="ripple">Ripple</option>
+              <option value="chromatic">Chromatic</option>
+            </select>
           </div>
         )}
 

--- a/packages/ts/lights/src/model/ProjectContext.tsx
+++ b/packages/ts/lights/src/model/ProjectContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useReducer, useRef } from 'react'
 import type { Dispatch, ReactNode } from 'react'
-import type { ImageLayer, Layer, Project, Slide, Surface, TextLayer, Volume, VolumeCamera, VolumeEditMode } from './types'
+import type { ImageLayer, Layer, Project, ShaderLayer, ShaderPreset, Slide, Surface, TextLayer, Volume, VolumeCamera, VolumeEditMode } from './types'
 
 export type EditorMode = 'stage' | 'surface' | 'volume-align' | 'volume-editor'
 
@@ -52,6 +52,7 @@ export type ProjectAction =
   | { type: 'layer:add'; slideId: string; surfaceId: string }
   | { type: 'layer:add-image'; slideId: string; surfaceId: string; src: string; name: string }
   | { type: 'layer:add-text'; slideId: string; surfaceId: string }
+  | { type: 'layer:add-shader'; slideId: string; surfaceId: string; preset?: ShaderPreset }
   | { type: 'layer:remove'; slideId: string; surfaceId: string; layerId: string }
   | { type: 'layer:update'; slideId: string; surfaceId: string; layer: Layer }
   | { type: 'layer:reorder'; slideId: string; surfaceId: string; layerIds: string[] }
@@ -332,6 +333,25 @@ function applyLayerAction(state: ProjectState, action: LayerAction): ProjectStat
         name: action.name,
         visible: true,
         src: action.src,
+        transform: { x: 0.5, y: 0.5, w: 1.0, h: 1.0, rotation: 0 },
+      }
+      return {
+        ...patchSurfaceLayers(state, action.slideId, action.surfaceId, layers => [layer, ...layers]),
+        selectedLayerId: layer.id,
+      }
+    }
+
+    case 'layer:add-shader': {
+      const slide = project.slides.find(s => s.id === action.slideId)
+      const surface = slide?.surfaces.find(sf => sf.id === action.surfaceId)
+      if (!surface) return state
+      const layer: ShaderLayer = {
+        id: crypto.randomUUID(),
+        type: 'shader',
+        name: `Shader ${surface.layers.length + 1}`,
+        visible: true,
+        preset: action.preset ?? 'pulse',
+        uniforms: { uIntensity: 0 },
         transform: { x: 0.5, y: 0.5, w: 1.0, h: 1.0, rotation: 0 },
       }
       return {

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -1,12 +1,13 @@
 import type { Point as BasePoint, GraphConfig } from '../ipc/types'
-import type { 
-  VolumeShapeType, VolumeEditMode, Vec3, VolumeCamera, 
+import type {
+  VolumeShapeType, VolumeEditMode, Vec3, VolumeCamera,
   VolumeShape as BaseVolumeShape, Volume as BaseVolume,
   SolidLayer as BaseSolidLayer, ImageLayer as BaseImageLayer, TextLayer as BaseTextLayer,
+  ShaderLayer as BaseShaderLayer, ShaderPreset,
   LayerTransform as BaseLayerTransform, Point, Surface as BaseSurface
 } from '@lights/three-scene'
 
-export type { GraphConfig, VolumeShapeType, VolumeEditMode, Vec3, VolumeCamera, Point }
+export type { GraphConfig, VolumeShapeType, VolumeEditMode, Vec3, VolumeCamera, Point, ShaderPreset }
 
 export type Polygon = BasePoint[]
 
@@ -17,9 +18,25 @@ export interface LayerTransform extends BaseLayerTransform {
 export interface SolidLayer extends BaseSolidLayer { transform: LayerTransform }
 export interface ImageLayer extends BaseImageLayer { transform: LayerTransform }
 export interface TextLayer extends BaseTextLayer { transform: LayerTransform }
-export type Layer = SolidLayer | ImageLayer | TextLayer
+export interface ShaderLayer extends BaseShaderLayer { transform: LayerTransform }
+export type Layer = SolidLayer | ImageLayer | TextLayer | ShaderLayer
 
-export interface Reaction { id: string }
+// ── Reactions ─────────────────────────────────────────────────────────────────
+
+export type ReactionTrigger =
+  | { kind: 'detection'; moduleId: string }
+
+export type ReactionAction =
+  | { kind: 'shader:setUniform'; layerId: string; uniform: string; value: number }
+  | { kind: 'layer:opacity'; layerId: string; value: number }
+
+export interface Reaction {
+  id: string
+  name: string
+  trigger: ReactionTrigger
+  action: ReactionAction
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface Calibration {} // populated by M6 (camera-to-projector mapping)
 

--- a/packages/ts/lights/vite.config.ts
+++ b/packages/ts/lights/vite.config.ts
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react'
 import electron from 'vite-plugin-electron/simple'
 
 export default defineConfig({
+  resolve: {
+    // Match tsconfig.base.json customConditions so Vite resolves workspace lib
+    // packages to their TypeScript source rather than the pre-built dist JS.
+    conditions: ['@lights/source'],
+  },
   plugins: [
     react(),
     electron({


### PR DESCRIPTION
Closes #60

Depends on #63 (data model — merge first).

## What

Three animated GLSL shader presets rendered in the Three.js pipeline on top of surface canvas textures. Adding a ⚡ shader layer to any surface makes it animate immediately — no reactions needed yet.

### Presets

| Name | Behaviour | Reaction uniform |
|------|-----------|-----------------|
| `pulse` | Flowing blue/purple shimmer that breathes in and out | `uIntensity` — boosts brightness |
| `ripple` | Concentric rings expanding from center | `uIntensity` — speeds up rings + shifts colour to gold |
| `chromatic` | RGB prism split / colour aberration | `uIntensity` — widens the channel split |

`uTime` is driven by a `requestAnimationFrame` loop. `uIntensity` starts at 0 and will be set by the reaction engine in #61.

### Architecture

- `buildHomographyGeo` extracted from `buildSurfaceMesh` — shared geometry builder for both canvas-texture and shader meshes
- `buildShaderLayerMeshes(surface)` returns one `THREE.Mesh` per visible `ShaderLayer`, stored in a separate `shaderGroup` above the surface group
- `disposeShaderLayerMesh` for proper WebGL cleanup
- ShaderLayer is excluded from the canvas 2D texture compositor (it renders as its own pass)
- rAF loop starts when any surface has a visible shader layer, stops otherwise
- Same pattern applied to `OutputApp` so the output window also animates

### UI additions

- ⚡ button in `LayerToolbar` to add a shader layer
- Preset badge in `LayerList` (first letter: P / R / C)
- Dashed purple placeholder in the flat surface editor (`LayerObject`)
- Preset dropdown in `SurfacePanel` for the selected shader layer

### Vite fix

Added `resolve.conditions: ['@lights/source']` to `vite.config.ts`, matching `tsconfig.base.json customConditions`. This makes Vite resolve workspace lib packages to their TypeScript source instead of the pre-built dist JS — prevents stale dist from breaking the build.

## Test plan

- [ ] Open the app, select a surface, enter surface editor
- [ ] Click ⚡ in the layer toolbar → shader layer appears in list with "P" badge
- [ ] Return to stage view → surface shows animated pulse shader
- [ ] In surface panel, change preset to ripple/chromatic → surface updates
- [ ] Add a second surface with a different preset → both animate independently
- [ ] Toggle shader layer visibility → animation stops when no shader layers remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)