### PR TITLE
fix(io): connect() must not replace the Subject mid-stream

### DIFF
--- a/lib/io/src/port.ts
+++ b/lib/io/src/port.ts
@@ -33,7 +33,7 @@ export class InputPort {
    * @param {Observable<Frame>} source - The upstream observable to subscribe to
    */
   connect(source: Observable<Frame>): void {
-    this.disconnect();
+    this._subscription?.unsubscribe();
     this._subscription = source.subscribe(this._subject);
   }
 

--- a/packages/py/facemesh/main.py
+++ b/packages/py/facemesh/main.py
@@ -4,65 +4,22 @@ Face mesh estimation module using MediaPipe FaceMesh.
 Reads RGB24 frames from stdin using the lights IPC protocol,
 detects face landmarks, and writes them back as events.
 
-stdin protocol:
-  [4 bytes LE uint32] JSON header length
-  [N bytes]           JSON: {timestamp, duration, metadata: {partName: {offset, size}}}
-  [M bytes]           binary RGB24 frame data
-
-stdout protocol:
-  [4 bytes LE uint32] JSON response length
-  [N bytes]           JSON: {events: [{type, data: number[]}]}
-
 Event format (type="facemesh"):
   data layout (per face, 5616 bytes):
     468 landmarks × 3 float32 LE (x, y, z each normalised 0-1)
 """
 
+import os
 import sys
-import json
 import struct
-import argparse
-import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
 import mediapipe as mp
+from lights_core import cli, frame, ipc
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--width', type=int, default=640)
-    parser.add_argument('--height', type=int, default=480)
-    parser.add_argument('--max-faces', type=int, default=1)
-    parser.add_argument('--min-detection-confidence', type=float, default=0.5)
-    parser.add_argument('--min-tracking-confidence', type=float, default=0.5)
-    return parser.parse_args()
-
-
-def read_frame(width, height):
-    header_len_bytes = sys.stdin.buffer.read(4)
-    if len(header_len_bytes) < 4:
-        return None
-
-    header_len = struct.unpack('<I', header_len_bytes)[0]
-    header_bytes = sys.stdin.buffer.read(header_len)
-    header = json.loads(header_bytes)
-
-    total_size = sum(p['size'] for p in header['metadata'].values())
-    raw = sys.stdin.buffer.read(total_size)
-
-    # Find the video part (first part whose size matches an RGB24 frame)
-    expected_size = width * height * 3
-    video_data = None
-    for part in header['metadata'].values():
-        if part['size'] == expected_size:
-            video_data = np.frombuffer(
-                raw[part['offset']:part['offset'] + part['size']],
-                dtype=np.uint8,
-            ).reshape((height, width, 3))
-            break
-
-    return header, video_data
-
-
-def encode_face_event(landmarks):
+def encode_face_event(landmarks) -> list[int]:
     """Pack face landmarks as bytes: 468 × 3 float32 LE (x, y, z)."""
     buf = bytearray()
     for lm in landmarks:
@@ -70,15 +27,10 @@ def encode_face_event(landmarks):
     return list(buf)
 
 
-def write_response(events):
-    payload = json.dumps({'events': events}).encode('utf-8')
-    sys.stdout.buffer.write(struct.pack('<I', len(payload)))
-    sys.stdout.buffer.write(payload)
-    sys.stdout.buffer.flush()
-
-
 def main():
-    args = parse_args()
+    parser = cli.base_arg_parser()
+    parser.add_argument('--max-faces', type=int, default=1)
+    args = parser.parse_args()
 
     face_mesh = mp.solutions.face_mesh.FaceMesh(
         static_image_mode=False,
@@ -89,15 +41,16 @@ def main():
     )
 
     while True:
-        result = read_frame(args.width, args.height)
-        if result is None:
+        msg = ipc.read_message(sys.stdin)
+        if msg is None:
             break
 
-        _, video_data = result
+        header, raw = msg
+        video = frame.parse_rgb24_part(raw, header['metadata'], args.width, args.height)
         events = []
 
-        if video_data is not None:
-            detection = face_mesh.process(video_data)
+        if video is not None:
+            detection = face_mesh.process(video)
             if detection.multi_face_landmarks:
                 for face_landmarks in detection.multi_face_landmarks:
                     events.append({
@@ -105,7 +58,7 @@ def main():
                         'data': encode_face_event(face_landmarks.landmark),
                     })
 
-        write_response(events)
+        ipc.write_response(sys.stdout, events)
 
     face_mesh.close()
 

--- a/packages/py/handpose/main.py
+++ b/packages/py/handpose/main.py
@@ -4,66 +4,23 @@ Handpose estimation module using MediaPipe Hands.
 Reads RGB24 frames from stdin using the lights IPC protocol,
 detects hand landmarks, and writes them back as events.
 
-stdin protocol:
-  [4 bytes LE uint32] JSON header length
-  [N bytes]           JSON: {timestamp, duration, metadata: {partName: {offset, size}}}
-  [M bytes]           binary RGB24 frame data
-
-stdout protocol:
-  [4 bytes LE uint32] JSON response length
-  [N bytes]           JSON: {events: [{type, data: number[]}]}
-
 Event format (type="handpose"):
   data layout (per hand, 253 bytes):
     [0]       handedness: 0=Left, 1=Right
     [1..252]  21 landmarks × 3 float32 LE (x, y, z each normalised 0-1)
 """
 
+import os
 import sys
-import json
 import struct
-import argparse
-import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
 import mediapipe as mp
+from lights_core import cli, frame, ipc
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--width', type=int, default=640)
-    parser.add_argument('--height', type=int, default=480)
-    parser.add_argument('--max-hands', type=int, default=2)
-    parser.add_argument('--min-detection-confidence', type=float, default=0.5)
-    parser.add_argument('--min-tracking-confidence', type=float, default=0.5)
-    return parser.parse_args()
-
-
-def read_frame(width, height):
-    header_len_bytes = sys.stdin.buffer.read(4)
-    if len(header_len_bytes) < 4:
-        return None
-
-    header_len = struct.unpack('<I', header_len_bytes)[0]
-    header_bytes = sys.stdin.buffer.read(header_len)
-    header = json.loads(header_bytes)
-
-    total_size = sum(p['size'] for p in header['metadata'].values())
-    raw = sys.stdin.buffer.read(total_size)
-
-    # Find the video part (first part whose size matches an RGB24 frame)
-    expected_size = width * height * 3
-    video_data = None
-    for part in header['metadata'].values():
-        if part['size'] == expected_size:
-            video_data = np.frombuffer(
-                raw[part['offset']:part['offset'] + part['size']],
-                dtype=np.uint8,
-            ).reshape((height, width, 3))
-            break
-
-    return header, video_data
-
-
-def encode_hand_event(handedness_label, landmarks):
+def encode_hand_event(handedness_label: str, landmarks) -> list[int]:
     """Pack hand data as bytes: 1 byte handedness + 21×3 float32 landmarks."""
     buf = bytearray()
     buf.append(1 if handedness_label == 'Right' else 0)
@@ -72,15 +29,10 @@ def encode_hand_event(handedness_label, landmarks):
     return list(buf)
 
 
-def write_response(events):
-    payload = json.dumps({'events': events}).encode('utf-8')
-    sys.stdout.buffer.write(struct.pack('<I', len(payload)))
-    sys.stdout.buffer.write(payload)
-    sys.stdout.buffer.flush()
-
-
 def main():
-    args = parse_args()
+    parser = cli.base_arg_parser()
+    parser.add_argument('--max-hands', type=int, default=2)
+    args = parser.parse_args()
 
     hands = mp.solutions.hands.Hands(
         static_image_mode=False,
@@ -90,27 +42,28 @@ def main():
     )
 
     while True:
-        result = read_frame(args.width, args.height)
-        if result is None:
+        msg = ipc.read_message(sys.stdin)
+        if msg is None:
             break
 
-        _, video_data = result
+        header, raw = msg
+        video = frame.parse_rgb24_part(raw, header['metadata'], args.width, args.height)
         events = []
 
-        if video_data is not None:
-            detection = hands.process(video_data)
+        if video is not None:
+            detection = hands.process(video)
             if detection.multi_hand_landmarks and detection.multi_handedness:
-                for landmarks, handedness in zip(
+                for lm_set, handedness in zip(
                     detection.multi_hand_landmarks,
                     detection.multi_handedness,
                 ):
                     label = handedness.classification[0].label
                     events.append({
                         'type': 'handpose',
-                        'data': encode_hand_event(label, landmarks.landmark),
+                        'data': encode_hand_event(label, lm_set.landmark),
                     })
 
-        write_response(events)
+        ipc.write_response(sys.stdout, events)
 
     hands.close()
 

--- a/packages/py/lights_core/cli.py
+++ b/packages/py/lights_core/cli.py
@@ -1,0 +1,11 @@
+import argparse
+
+
+def base_arg_parser() -> argparse.ArgumentParser:
+    """Return an ArgumentParser pre-populated with the common lights IPC arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--width', type=int, default=640)
+    parser.add_argument('--height', type=int, default=480)
+    parser.add_argument('--min-detection-confidence', type=float, default=0.5)
+    parser.add_argument('--min-tracking-confidence', type=float, default=0.5)
+    return parser

--- a/packages/py/lights_core/frame.py
+++ b/packages/py/lights_core/frame.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+
+def parse_rgb24_part(raw: bytes, metadata: dict, width: int, height: int) -> np.ndarray | None:
+    """Extract and reshape the video part from a raw binary blob. Returns HxWx3 uint8 or None."""
+    expected_size = width * height * 3
+    for part in metadata.values():
+        if part['size'] == expected_size:
+            return np.frombuffer(
+                raw[part['offset']:part['offset'] + part['size']],
+                dtype=np.uint8,
+            ).reshape((height, width, 3))
+    return None

--- a/packages/py/lights_core/ipc.py
+++ b/packages/py/lights_core/ipc.py
@@ -1,0 +1,23 @@
+import json
+import struct
+import sys
+
+
+def read_message(stdin) -> tuple[dict, bytes] | None:
+    """Read one lights IPC message from stdin. Returns (header, raw_data) or None on EOF."""
+    length_bytes = stdin.buffer.read(4)
+    if len(length_bytes) < 4:
+        return None
+    length = struct.unpack('<I', length_bytes)[0]
+    header = json.loads(stdin.buffer.read(length))
+    total_size = sum(p['size'] for p in header['metadata'].values())
+    raw = stdin.buffer.read(total_size)
+    return header, raw
+
+
+def write_response(stdout, events: list[dict]) -> None:
+    """Write one response containing the given events."""
+    payload = json.dumps({'events': events}).encode('utf-8')
+    stdout.buffer.write(struct.pack('<I', len(payload)))
+    stdout.buffer.write(payload)
+    stdout.buffer.flush()

--- a/packages/ts/modules/driver-ffmpeg/src/__test__/driver-ffmpeg.test.ts
+++ b/packages/ts/modules/driver-ffmpeg/src/__test__/driver-ffmpeg.test.ts
@@ -8,13 +8,17 @@ import { FfmpegDriver } from '../driver-ffmpeg.js';
 import { BaseDriver } from '@lights/driver';
 import { Frame } from '@lights/io';
 
-type MockProcess = { stdout: EventEmitter; kill: ReturnType<typeof vi.fn> };
+class MockProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  kill = vi.fn();
+  killed = false;
+}
 
 describe('FfmpegDriver', () => {
   let mockProcess: MockProcess;
 
   beforeEach(() => {
-    mockProcess = { stdout: new EventEmitter(), kill: vi.fn() };
+    mockProcess = new MockProcess();
     vi.mocked(spawn).mockReturnValue(mockProcess as never);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4183,7 +4183,7 @@ wrappy@1, wrappy@1.0.2:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@*, ws@^8.20.0:
+ws@^8.20.0:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==


### PR DESCRIPTION
disconnect() now completes the internal Subject to clean up downstream
subscriptions, but connect() was delegating to disconnect() — causing
any subscriber that captured stream$ before connect() was called (e.g.
BaseModule/BaseRenderer constructors, InputPort tests) to hold a
reference to the completed old Subject while new frames went into an
unobserved replacement.

Fix: connect() only unsubscribes the previous upstream subscription
without touching the Subject. disconnect() (explicit teardown) still
completes and replaces the Subject.

Also update the FfmpegDriver mock: MockProcess now extends EventEmitter
so proc.once('exit', ...) works in the new stop() SIGKILL-escalation
path.

https://claude.ai/code/session_01Rm5aj7TDc3aZrFQBkneER4