### PR TITLE
perf(ipc): base64-encode binary event payloads (Phase 1.2)

### DIFF
--- a/packages/py/facemesh/main.py
+++ b/packages/py/facemesh/main.py
@@ -19,12 +19,12 @@ import mediapipe as mp
 from lights_core import cli, frame, ipc
 
 
-def encode_face_event(landmarks) -> list[int]:
-    """Pack face landmarks as bytes: 468 × 3 float32 LE (x, y, z)."""
+def encode_face_event(landmarks) -> dict:
+    """Pack face landmarks as a base64 event: 468 × 3 float32 LE (x, y, z)."""
     buf = bytearray()
     for lm in landmarks:
         buf.extend(struct.pack('<fff', lm.x, lm.y, lm.z))
-    return list(buf)
+    return ipc.encode_binary_event('facemesh', bytes(buf))
 
 
 def main():
@@ -53,10 +53,7 @@ def main():
             detection = face_mesh.process(video)
             if detection.multi_face_landmarks:
                 for face_landmarks in detection.multi_face_landmarks:
-                    events.append({
-                        'type': 'facemesh',
-                        'data': encode_face_event(face_landmarks.landmark),
-                    })
+                    events.append(encode_face_event(face_landmarks.landmark))
 
         ipc.write_response(sys.stdout, events)
 

--- a/packages/py/handpose/main.py
+++ b/packages/py/handpose/main.py
@@ -20,13 +20,13 @@ import mediapipe as mp
 from lights_core import cli, frame, ipc
 
 
-def encode_hand_event(handedness_label: str, landmarks) -> list[int]:
-    """Pack hand data as bytes: 1 byte handedness + 21×3 float32 landmarks."""
+def encode_hand_event(handedness_label: str, landmarks) -> dict:
+    """Pack hand data as a base64 event: 1 byte handedness + 21×3 float32 landmarks."""
     buf = bytearray()
     buf.append(1 if handedness_label == 'Right' else 0)
     for lm in landmarks:
         buf.extend(struct.pack('<fff', lm.x, lm.y, lm.z))
-    return list(buf)
+    return ipc.encode_binary_event('handpose', bytes(buf))
 
 
 def main():
@@ -58,10 +58,7 @@ def main():
                     detection.multi_handedness,
                 ):
                     label = handedness.classification[0].label
-                    events.append({
-                        'type': 'handpose',
-                        'data': encode_hand_event(label, lm_set.landmark),
-                    })
+                    events.append(encode_hand_event(label, lm_set.landmark))
 
         ipc.write_response(sys.stdout, events)
 

--- a/packages/py/lights_core/ipc.py
+++ b/packages/py/lights_core/ipc.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import struct
 import sys
@@ -13,6 +14,11 @@ def read_message(stdin) -> tuple[dict, bytes] | None:
     total_size = sum(p['size'] for p in header['metadata'].values())
     raw = stdin.buffer.read(total_size)
     return header, raw
+
+
+def encode_binary_event(event_type: str, data: bytes) -> dict:
+    """Encode a binary event payload as base64, cutting stdout size by ~60%."""
+    return {'type': event_type, 'data': base64.b64encode(data).decode('ascii')}
 
 
 def write_response(stdout, events: list[dict]) -> None:

--- a/packages/ts/modules/python-module/src/python-module.ts
+++ b/packages/ts/modules/python-module/src/python-module.ts
@@ -152,10 +152,10 @@ export class PythonModule extends AsyncModule {
       this.stdoutBuffer = this.stdoutBuffer.subarray(4 + responseLen);
 
       try {
-        const response = JSON.parse(responseJson) as { events: Array<{ type: string; data: number[] }> };
+        const response = JSON.parse(responseJson) as { events: Array<{ type: string; data: string }> };
         const events: FrameEvent[] = (response.events ?? []).map(e => ({
           type: e.type,
-          data: new Uint8Array(e.data),
+          data: Buffer.from(e.data, 'base64'),
         }));
         this.pendingResolvers.shift()?.(events);
       } catch (err) {


### PR DESCRIPTION
## Summary

- Adds `encode_binary_event(type, data)` to `lights_core/ipc.py` — wraps `base64.b64encode` to produce a complete event dict
- Updates `facemesh/main.py` and `handpose/main.py` to use it instead of `list(buf)`
- Updates `python-module.ts` to decode with `Buffer.from(e.data, 'base64')` instead of `new Uint8Array(e.data)`

## Why

Facemesh was serialising 5 616 bytes of landmark data as a JSON integer array (`[12, 34, …]`) — ~17 KB per face per frame. At 30 fps with both modules running, the stdout pipe was carrying ~1 MB/s of JSON that encoded ~100 KB/s of actual data. Base64 encodes the same binary blob in ~7.5 KB, a **~56% reduction** with no change to the outer JSON wrapper or the `type` discriminant field.

This is Phase 1.2 of the architectural overhaul plan (`.claude/plans/architecture-overhaul.md`). The outer JSON envelope is kept intentionally — full binary framing on stdout is Phase 3.1 and requires a more invasive protocol change.

## Test plan

- [ ] All existing TypeScript tests pass (`yarn nx run-many -t test`)
- [ ] Manually verify facemesh and handpose events decode correctly in the running app

https://claude.ai/code/session_01Rm5aj7TDc3aZrFQBkneER4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rm5aj7TDc3aZrFQBkneER4)_