### PR TITLE
feat(model): project file versioning and migration chain (Phase 1.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,13 +110,27 @@ The following are the highest-leverage areas for reducing end-to-end inference l
 - **Base64 events**: Change `encode_face_event` / `encode_hand_event` in Python to emit base64, update `PythonModule.handleStdout` to decode. Cuts stdout payload by ~60%.
 - **Binary stdout framing**: Replace JSON wrapper with a fixed binary header for zero-copy deserialization.
 
+## Project File Versioning
+
+`.lights.json` files carry a top-level `version` integer. On open, `validateProject()` in
+`packages/ts/lights/src/model/schema.ts` migrates old files to `CURRENT_VERSION` before
+they reach the renderer. Files from a newer app version are rejected with a user-facing dialog.
+
+**To add a migration** (e.g. when changing `Slide`, `Surface`, or `Layer` shapes):
+1. Append a function to the `migrations` array in `packages/ts/lights/src/model/migrations.ts`.
+   `CURRENT_VERSION` increments automatically — no manual bookkeeping.
+2. Update the affected types in `types.ts`.
+3. Add a row to the migration history table in `migrations.ts`.
+
+See the JSDoc block at the top of `migrations.ts` for the full how-to.
+
 ## Development Commands
 
 ```bash
 yarn nx test @lights/graph          # run graph unit tests
 yarn nx test @lights/python-module  # run python-module unit tests
 yarn nx run-many -t test            # run all tests
-yarn nx build lights                # typecheck + build Electron app
+yarn nx build @lights/app           # typecheck + build Electron app
 yarn nx lint lights                 # lint
 ```
 

--- a/packages/ts/lights/electron/main.ts
+++ b/packages/ts/lights/electron/main.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { registerGraphHandlers } from './graph'
+import { validateProject } from '../src/model/schema'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -111,16 +112,16 @@ function buildMenu() {
             const filePath = result.filePaths[0]
             try {
               const data = await fs.readFile(filePath, 'utf-8')
-              const project = JSON.parse(data)
+              const project = validateProject(JSON.parse(data))
               currentFilePath = filePath
               isDirty = false
               win?.setTitle(winTitle())
               win?.webContents.send('project:opened', { project, filePath })
-            } catch {
+            } catch (err) {
               await dialog.showMessageBox(win!, {
                 type: 'error',
                 message: 'Could not open project',
-                detail: `Failed to read ${path.basename(filePath)}.`,
+                detail: err instanceof Error ? err.message : `Failed to read ${path.basename(filePath)}.`,
               })
             }
           },

--- a/packages/ts/lights/src/contexts/ProjectContext.tsx
+++ b/packages/ts/lights/src/contexts/ProjectContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useReducer, useRef } from 'react'
 import type { Dispatch, ReactNode } from 'react'
 import type { DetectionCanvasLayer, ImageLayer, Layer, Project, Slide, Surface, TextLayer, Volume, VolumeCamera, VolumeEditMode } from '../model/types'
+import { CURRENT_VERSION } from '../model/schema'
 
 export type EditorMode = 'stage' | 'surface' | 'volume-align' | 'volume-editor'
 
@@ -19,7 +20,7 @@ export interface ProjectState {
 }
 
 const initial: ProjectState = {
-  project: { slides: [], calibration: {} },
+  project: { version: CURRENT_VERSION, slides: [], calibration: {} },
   selectedSlideId: null,
   selectedSurfaceId: null,
   selectedLayerId: null,

--- a/packages/ts/lights/src/model/migrations.ts
+++ b/packages/ts/lights/src/model/migrations.ts
@@ -1,0 +1,30 @@
+import type { Project } from './types'
+
+type Migration = (prev: unknown) => unknown
+
+const migrations: Migration[] = [
+  // v0 → v1: add version field, ensure graphConfig.modules defaults to {}
+  (raw) => {
+    const obj = raw as Record<string, unknown>
+    return {
+      ...obj,
+      version: 1,
+      slides: Array.isArray(obj.slides)
+        ? (obj.slides as Record<string, unknown>[]).map(slide => ({
+            ...slide,
+            graphConfig: slide.graphConfig ?? { modules: {} },
+          }))
+        : [],
+    }
+  },
+]
+
+export const CURRENT_VERSION = migrations.length
+
+export function migrate(raw: unknown, fromVersion: number): Project {
+  let current = raw
+  for (let v = fromVersion; v < CURRENT_VERSION; v++) {
+    current = migrations[v](current)
+  }
+  return current as Project
+}

--- a/packages/ts/lights/src/model/migrations.ts
+++ b/packages/ts/lights/src/model/migrations.ts
@@ -1,3 +1,38 @@
+/**
+ * # Project file migration system
+ *
+ * ## How versioning works
+ *
+ * Every saved `.lights.json` file carries a top-level `version` integer.
+ * Files written before versioning was introduced have no `version` field
+ * and are treated as v0.
+ *
+ * `CURRENT_VERSION` equals `migrations.length`. It increments automatically
+ * each time a migration is appended — no manual bookkeeping needed.
+ *
+ * On `project:open`, `validateProject()` (schema.ts) runs the migration chain
+ * to bring the file up to `CURRENT_VERSION` before it reaches the renderer.
+ * Files from a newer app version are rejected with a user-facing error.
+ *
+ * ## Adding a migration
+ *
+ * 1. Append a function to the `migrations` array below.
+ *    - Index N is the migration from vN → v(N+1).
+ *    - Input is `unknown` — the previous (potentially ancient) shape.
+ *    - Output should match the shape expected by the *next* migration
+ *      (or `Project` if it is the last one).
+ *    - Treat input defensively: use `?? fallback` for any new required field.
+ *    - Keep transformations non-destructive: spread first, then override.
+ * 2. Update `Project` in `types.ts` if the shape changed.
+ * 3. Add a comment explaining what changed and why.
+ *
+ * ## Migration history
+ *
+ * | From → To | Change                                                    |
+ * |-----------|-----------------------------------------------------------|
+ * | v0 → v1   | Added `version` field; defaulted `graphConfig.modules` to `{}` on each slide |
+ */
+
 import type { Project } from './types'
 
 type Migration = (prev: unknown) => unknown

--- a/packages/ts/lights/src/model/schema.ts
+++ b/packages/ts/lights/src/model/schema.ts
@@ -1,0 +1,19 @@
+import type { Project } from './types'
+import { migrate, CURRENT_VERSION } from './migrations'
+
+export { CURRENT_VERSION }
+
+export function validateProject(raw: unknown): Project {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('Invalid project file: expected a JSON object')
+  }
+  const version = (raw as Record<string, unknown>).version
+  const fromVersion = typeof version === 'number' ? version : 0
+  if (fromVersion > CURRENT_VERSION) {
+    throw new Error(
+      `Project file was created with a newer version of Lights (v${fromVersion}). ` +
+      `This build supports up to v${CURRENT_VERSION}. Please update the app.`
+    )
+  }
+  return migrate(raw, fromVersion)
+}

--- a/packages/ts/lights/src/model/types.ts
+++ b/packages/ts/lights/src/model/types.ts
@@ -49,6 +49,7 @@ export interface Slide {
 }
 
 export interface Project {
+  version: number
   slides: Slide[]
   calibration: Calibration
 }


### PR DESCRIPTION
## Summary

- Adds `version: number` to the `Project` type
- Creates `src/model/migrations.ts`: a typed migration chain (v0→v1 adds the `version` field and defaults `graphConfig.modules` to `{}`)
- Creates `src/model/schema.ts`: `validateProject()` validates structure, rejects files from newer app versions with a clear error message, and runs the migration chain
- Updates `electron/main.ts` `project:open` handler to call `validateProject()` — migration errors are now shown in a user-facing dialog instead of silently crashing
- Updates `ProjectContext` initial state to stamp `version: CURRENT_VERSION` on new projects

## Why

The project file had no version field. Any future change to `Volume`, `Reaction`, `GraphConfig`, or `Surface` shapes would silently produce wrong behaviour or crash when old files were loaded. Adding a migration chain now means old files are upgraded automatically, and files from newer app versions are rejected with a clear error rather than a silent crash.

## Adding future migrations

Append a function to the `migrations` array in `migrations.ts`. `CURRENT_VERSION` increments automatically (it equals `migrations.length`).

## Test plan

- [ ] All tests pass (`yarn nx run-many -t test`)
- [ ] Build succeeds (`yarn nx build @lights/app`)
- [ ] Open a project file that was saved before this change — it loads correctly (migrated from v0 to v1)
- [ ] Open a hand-edited file with `"version": 99` — app shows an error dialog instead of crashing

https://claude.ai/code/session_01Rm5aj7TDc3aZrFQBkneER4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rm5aj7TDc3aZrFQBkneER4)_