### PR TITLE
ci: add Playwright e2e job for Electron app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,49 @@ jobs:
       - run: yarn install --frozen-lockfile
 
       - run: yarn nx run-many -t lint test
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: main
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile
+
+      - name: Install Electron system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb libglib2.0-0 libnss3 libnspr4 \
+            libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 \
+            libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 \
+            libasound2t64 || sudo apt-get install -y -qq libasound2
+
+      - name: Build Electron app
+        run: yarn nx build @lights/app
+
+      - name: Run e2e tests
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" yarn nx e2e @lights/e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: packages/ts/e2e/playwright-report/
+          retention-days: 7
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: packages/ts/e2e/test-results/
+          retention-days: 7


### PR DESCRIPTION
## Summary

- Adds an `e2e` job to the CI workflow that runs after the existing `main` (lint + unit tests) job
- Installs Electron system dependencies (NSS, GBM, ALSA, etc.) and Xvfb for headless display
- Builds the Electron app, then runs Playwright tests via `yarn nx e2e @lights/e2e`
- Uploads the HTML Playwright report as an artifact on every run, and full test results (screenshots, traces) on failure

## Test plan

- [ ] CI passes on this PR — `main` job (lint/test) and `e2e` job both green
- [ ] Playwright report artifact is visible in the Actions run summary
- [ ] If a test is broken, `playwright-test-results` artifact contains screenshots and traces

https://claude.ai/code/session_01XkoMfumuZfmLJUivuWPNPg

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkoMfumuZfmLJUivuWPNPg)_