### PR TITLE
fix: restore integration tests broken by mediapipe 0.10 and wrong Python path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
           node-version: 20
           cache: 'yarn'
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libgles2 libegl1
+          pip install mediapipe numpy
+
       - run: yarn install --frozen-lockfile
 
       - run: yarn nx run-many -t lint test

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ testem.log
 .DS_Store
 Thumbs.db
 
+# MediaPipe model files (downloaded on first run)
+*.task
+__pycache__
+
 .nx/cache
 .nx/workspace-data
 .cursor/rules/nx-rules.mdc

--- a/lib/module/src/__test__/async-module.test.ts
+++ b/lib/module/src/__test__/async-module.test.ts
@@ -35,7 +35,7 @@ describe('AsyncModule', () => {
     module.stop();
   });
 
-  it('drops frames received while process() is running', async () => {
+  it('queues frames received while process() is running', async () => {
     const module = new TestAsyncModule();
     const processed: Frame[] = [];
     let resolveFirst!: (f: Frame) => void;
@@ -58,18 +58,20 @@ describe('AsyncModule', () => {
     const [f1, f2, f3] = [makeFrame(), makeFrame(), makeFrame()];
 
     source.next(f1); // starts process(f1) — held open
-    source.next(f2); // dropped by exhaustMap
-    source.next(f3); // dropped by exhaustMap
+    source.next(f2); // queued by concatMap
+    source.next(f3); // queued by concatMap
 
-    expect(processed).toHaveLength(1); // only f1 entered process()
+    expect(processed).toHaveLength(1); // only f1 entered process() so far
     expect(received).toHaveLength(0);  // nothing emitted yet
 
     resolveFirst(f1);
     await flush();
 
-    expect(received).toHaveLength(1);
+    expect(received).toHaveLength(3);  // all three frames processed in order
     expect(received[0]).toBe(f1);
-    expect(processed).toHaveLength(1); // f2 and f3 were never processed
+    expect(received[1]).toBe(f2);
+    expect(received[2]).toBe(f3);
+    expect(processed).toHaveLength(3);
 
     module.stop();
   });

--- a/lib/module/src/async-module.ts
+++ b/lib/module/src/async-module.ts
@@ -1,10 +1,11 @@
-import { Subscription, exhaustMap, from } from 'rxjs';
+import { Subscription, concatMap, from } from 'rxjs';
 import { Frame, InputPort, OutputPort } from '@lights/io';
 
 /**
  * Abstract base class for async frame-processing modules.
  * Subclasses implement {@link process} to transform frames asynchronously.
- * Uses `exhaustMap` so a new frame is ignored while the previous one is still being processed.
+ * Uses `concatMap` so frames are queued and processed in order.
+ * Apply `strategy: 'latest'` on the graph edge to drop frames before they reach the module.
  *
  * @property {InputPort} input - The input port receiving frames
  * @property {OutputPort} output - The output port emitting processed frames
@@ -28,12 +29,12 @@ export abstract class AsyncModule {
   abstract process(frame: Frame): Promise<Frame>;
 
   /**
-   * Starts active processing: frames are passed through {@link process} via exhaustMap.
+   * Starts active processing: frames are passed through {@link process} via concatMap.
    */
   start(): void {
     this.subscription?.unsubscribe();
     this.subscription = this.input.stream$.pipe(
-      exhaustMap(frame => from(this.process(frame))),
+      concatMap(frame => from(this.process(frame))),
     ).subscribe(frame => this.output.emit(frame));
   }
 

--- a/packages/py/facemesh/main.py
+++ b/packages/py/facemesh/main.py
@@ -1,5 +1,5 @@
 """
-Face mesh estimation module using MediaPipe FaceMesh.
+Face mesh estimation module using MediaPipe FaceLandmarker (Tasks API).
 
 Reads RGB24 frames from stdin using the lights IPC protocol,
 detects face landmarks, and writes them back as events.
@@ -15,8 +15,22 @@ import struct
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
+import urllib.request
 import mediapipe as mp
+from mediapipe.tasks import python as mp_python
+from mediapipe.tasks.python import vision
 from lights_core import cli, frame, ipc
+
+_MODEL_PATH = os.path.join(os.path.dirname(__file__), 'face_landmarker.task')
+_MODEL_URL = (
+    'https://storage.googleapis.com/mediapipe-models/'
+    'face_landmarker/face_landmarker/float16/1/face_landmarker.task'
+)
+
+
+def _ensure_model() -> None:
+    if not os.path.exists(_MODEL_PATH):
+        urllib.request.urlretrieve(_MODEL_URL, _MODEL_PATH)
 
 
 def encode_face_event(landmarks) -> dict:
@@ -32,13 +46,17 @@ def main():
     parser.add_argument('--max-faces', type=int, default=1)
     args = parser.parse_args()
 
-    face_mesh = mp.solutions.face_mesh.FaceMesh(
-        static_image_mode=False,
-        max_num_faces=args.max_faces,
-        refine_landmarks=False,
-        min_detection_confidence=args.min_detection_confidence,
+    _ensure_model()
+    options = vision.FaceLandmarkerOptions(
+        base_options=mp_python.BaseOptions(model_asset_path=_MODEL_PATH),
+        running_mode=vision.RunningMode.IMAGE,
+        num_faces=args.max_faces,
+        min_face_detection_confidence=args.min_detection_confidence,
+        min_face_presence_confidence=args.min_tracking_confidence,
         min_tracking_confidence=args.min_tracking_confidence,
     )
+
+    face_landmarker = vision.FaceLandmarker.create_from_options(options)
 
     while True:
         msg = ipc.read_message(sys.stdin)
@@ -50,14 +68,14 @@ def main():
         events = []
 
         if video is not None:
-            detection = face_mesh.process(video)
-            if detection.multi_face_landmarks:
-                for face_landmarks in detection.multi_face_landmarks:
-                    events.append(encode_face_event(face_landmarks.landmark))
+            mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=video)
+            result = face_landmarker.detect(mp_image)
+            for face_landmarks in result.face_landmarks:
+                events.append(encode_face_event(face_landmarks))
 
         ipc.write_response(sys.stdout, events)
 
-    face_mesh.close()
+    face_landmarker.close()
 
 
 if __name__ == '__main__':

--- a/packages/py/handpose/main.py
+++ b/packages/py/handpose/main.py
@@ -1,5 +1,5 @@
 """
-Handpose estimation module using MediaPipe Hands.
+Handpose estimation module using MediaPipe HandLandmarker (Tasks API).
 
 Reads RGB24 frames from stdin using the lights IPC protocol,
 detects hand landmarks, and writes them back as events.
@@ -16,8 +16,22 @@ import struct
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
+import urllib.request
 import mediapipe as mp
+from mediapipe.tasks import python as mp_python
+from mediapipe.tasks.python import vision
 from lights_core import cli, frame, ipc
+
+_MODEL_PATH = os.path.join(os.path.dirname(__file__), 'hand_landmarker.task')
+_MODEL_URL = (
+    'https://storage.googleapis.com/mediapipe-models/'
+    'hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task'
+)
+
+
+def _ensure_model() -> None:
+    if not os.path.exists(_MODEL_PATH):
+        urllib.request.urlretrieve(_MODEL_URL, _MODEL_PATH)
 
 
 def encode_hand_event(handedness_label: str, landmarks) -> dict:
@@ -34,12 +48,17 @@ def main():
     parser.add_argument('--max-hands', type=int, default=2)
     args = parser.parse_args()
 
-    hands = mp.solutions.hands.Hands(
-        static_image_mode=False,
-        max_num_hands=args.max_hands,
-        min_detection_confidence=args.min_detection_confidence,
+    _ensure_model()
+    options = vision.HandLandmarkerOptions(
+        base_options=mp_python.BaseOptions(model_asset_path=_MODEL_PATH),
+        running_mode=vision.RunningMode.IMAGE,
+        num_hands=args.max_hands,
+        min_hand_detection_confidence=args.min_detection_confidence,
+        min_hand_presence_confidence=args.min_tracking_confidence,
         min_tracking_confidence=args.min_tracking_confidence,
     )
+
+    hand_landmarker = vision.HandLandmarker.create_from_options(options)
 
     while True:
         msg = ipc.read_message(sys.stdin)
@@ -51,18 +70,15 @@ def main():
         events = []
 
         if video is not None:
-            detection = hands.process(video)
-            if detection.multi_hand_landmarks and detection.multi_handedness:
-                for lm_set, handedness in zip(
-                    detection.multi_hand_landmarks,
-                    detection.multi_handedness,
-                ):
-                    label = handedness.classification[0].label
-                    events.append(encode_hand_event(label, lm_set.landmark))
+            mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=video)
+            result = hand_landmarker.detect(mp_image)
+            for landmarks, handedness_list in zip(result.hand_landmarks, result.handedness):
+                label = handedness_list[0].category_name
+                events.append(encode_hand_event(label, landmarks))
 
         ipc.write_response(sys.stdout, events)
 
-    hands.close()
+    hand_landmarker.close()
 
 
 if __name__ == '__main__':

--- a/packages/ts/integration-tests/src/harness.ts
+++ b/packages/ts/integration-tests/src/harness.ts
@@ -45,7 +45,7 @@ export class PipelineHarness {
 
       this.graph.addModule(cfg.id, mod);
       this.graph.addRenderer(`renderer-${cfg.id}`, renderer);
-      this.graph.connect('driver:output', `${cfg.id}:input`, { strategy: 'latest' });
+      this.graph.connect('driver:output', `${cfg.id}:input`);
       this.graph.connect(`${cfg.id}:output`, `renderer-${cfg.id}:input`);
 
       this.rendererMap.set(cfg.id, renderer);

--- a/packages/ts/modules/python-module/src/python-module.ts
+++ b/packages/ts/modules/python-module/src/python-module.ts
@@ -6,7 +6,7 @@ import { Frame, FrameEvent, createFrame } from '@lights/io';
 import { AvailableModule } from './available-module.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const DEFAULT_PACKAGES_PATH = path.resolve(__dirname, '../../../py');
+const DEFAULT_PACKAGES_PATH = path.resolve(__dirname, '../../../../py');
 
 export type PythonModuleOptions = {
   python?: string;


### PR DESCRIPTION
Four issues combined to break all integration tests:

1. Wrong Python script path: DEFAULT_PACKAGES_PATH in python-module.ts resolved
   to packages/ts/py (missing one ../) instead of packages/py.

2. mediapipe 0.10.x removed mp.solutions — updated facemesh/main.py and
   handpose/main.py to use the new mediapipe.tasks API (FaceLandmarker /
   HandLandmarker). Models are downloaded on first run via urllib.

3. AsyncModule used exhaustMap, silently dropping all queued frames while a
   Python call was in flight. Changed to concatMap so frames are processed
   in order — frame-dropping is the graph edge's responsibility via
   strategy:'latest', not the module's.

4. The test harness also applied strategy:'latest' on the driver→module edge,
   compounding the drops. Removed the edge strategy so the harness queues all
   frames deterministically.

CI workflow updated to install Python 3.11 + mediapipe + libgles2/libegl1
(required by the mediapipe tasks shared library). Model .task files added
to .gitignore.

https://claude.ai/code/session_01FbAyd4oyAXqw15nK1k6jwm