### PR TITLE
fix: add tsconfig.json to integration-tests and e2e packages

### DIFF
--- a/packages/ts/e2e/tsconfig.json
+++ b/packages/ts/e2e/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true
+  },
+  "include": ["playwright.config.ts", "tests/**/*.ts"]
+}

--- a/packages/ts/integration-tests/tsconfig.json
+++ b/packages/ts/integration-tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "fixtures/**/*.ts"]
+}


### PR DESCRIPTION
Both packages were missing tsconfig.json, so ESLint's TypeScript project
service couldn't resolve their source files and failed with "not found by
the project service" errors.

https://claude.ai/code/session_01CKL4GqthETCEvcv45xqNkY